### PR TITLE
Don't create new sets and allow early fail.

### DIFF
--- a/lib/set_basics.dart
+++ b/lib/set_basics.dart
@@ -15,8 +15,7 @@ extension SetBasics<E> on Set<E> {
   /// set.isEqualTo({'a', 'b', 'c', 'd'}); // false
   /// ```
   bool isEqualTo(Set<Object> other) =>
-      this.length == other.length &&
-      this.length == this.intersection(other).length;
+      this.length == other.length && this.containsAll(other);
 
   /// Returns `true` if [this] and [other] have no elements in common.
   ///


### PR DESCRIPTION
Comparing sets for equality doesn't need the creation of the intersection.

Making sure one set contains the other is sufficient, as we checked for the lengths. This prevents unnecessary allocations and has the chance to fail early without checking every element if not needed.