### PR TITLE
Add DateTimeBasics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.0]
+
+Added `DateTimeBasics`.
+
 ## [0.2.0] - 2020-04-24
 
 Add example and changelog.

--- a/lib/basics.dart
+++ b/lib/basics.dart
@@ -2,6 +2,7 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+export 'date_time_basics.dart';
 export 'int_basics.dart';
 export 'iterable_basics.dart';
 export 'list_basics.dart';

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -1,0 +1,30 @@
+// Copyright (c) 2020, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Utility extension methods for the core [DateTime] class.
+extension DateTimeBasics on DateTime {
+  /// Returns true if [this] occurs strictly before [other].
+  bool operator <(DateTime other) => compareTo(other) < 0;
+
+  /// Returns true if [this] occurs strictly after [other].
+  bool operator >(DateTime other) => compareTo(other) > 0;
+
+  /// Returns true if [this] occurs on or before [other].
+  bool operator <=(DateTime other) => compareTo(other) <= 0;
+
+  /// Returns true if [this] occurs on or after [other].
+  bool operator >=(DateTime other) => compareTo(other) >= 0;
+
+  /// Returns a new [DateTime] instance with [duration] added to [this].
+  ///
+  /// See [DateTime.add].
+  DateTime operator +(Duration duration) => this.add(duration);
+
+  /// Returns the [Duration] between [this] and [other].
+  ///
+  /// The returned [Duration] will be negative if [other] occurs after [this].
+  ///
+  /// See [DateTime.difference].
+  Duration operator -(DateTime other) => this.difference(other);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: basics
 description: A Dart library containing convenient extension methods on basic Dart objects.
-version: 0.2.0
+version: 0.3.0
 homepage: https://github.com/google/dart-basics
 authors:
   - johnsonmh@google.com <johnsonmh@google.com>

--- a/test/date_time_basics_test.dart
+++ b/test/date_time_basics_test.dart
@@ -1,0 +1,64 @@
+// Copyright (c) 2019, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:basics/date_time_basics.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final utcTime = DateTime.utc(2020, 3, 27, 13, 40, 56);
+  final utcTimeAfter = DateTime.utc(2020, 3, 27, 13, 40, 57);
+
+  final localTime = utcTime.toLocal();
+
+  group('Comparisons:', () {
+    test('DateTime < DateTime works', () {
+      expect(utcTime < utcTime, false);
+      expect(utcTime < utcTimeAfter, true);
+      expect(utcTimeAfter < utcTime, false);
+
+      expect(localTime < utcTime, false);
+      expect(localTime < utcTimeAfter, true);
+    });
+
+    test('DateTime > DateTime works', () {
+      expect(utcTime > utcTime, false);
+      expect(utcTime > utcTimeAfter, false);
+      expect(utcTimeAfter > utcTime, true);
+
+      expect(localTime > utcTime, false);
+      expect(utcTimeAfter > localTime, true);
+    });
+
+    test('DateTime <= DateTime works', () {
+      expect(utcTime <= utcTime, true);
+      expect(utcTime <= utcTimeAfter, true);
+      expect(utcTimeAfter <= utcTime, false);
+
+      expect(localTime <= utcTime, true);
+      expect(localTime <= utcTimeAfter, true);
+    });
+
+    test('DateTime >= DateTime works', () {
+      expect(utcTime >= utcTime, true);
+      expect(utcTime >= utcTimeAfter, false);
+      expect(utcTimeAfter >= utcTime, true);
+
+      expect(localTime >= utcTime, true);
+      expect(utcTimeAfter >= localTime, true);
+    });
+  });
+
+  test('DateTime + Duration works', () {
+    expect(utcTime + Duration(seconds: 1), utcTimeAfter);
+    expect((localTime + Duration(seconds: 1)).toUtc(), utcTimeAfter);
+
+    expect(utcTimeAfter + -Duration(seconds: 1), utcTime);
+  });
+
+  test('DateTime - DateTime works', () {
+    expect(utcTimeAfter - utcTime, Duration(seconds: 1));
+    expect(utcTime - utcTimeAfter, -Duration(seconds: 1));
+    expect(utcTimeAfter - localTime, Duration(seconds: 1));
+  });
+}


### PR DESCRIPTION
Extend `DateTime` with <, >, <=, >=, +, and - operators to make
comparisons and time manipulations easier to read.

In particular, these will let me stop having to figure out whether
`time1.difference(time2)` and `time1.compareTo(time2)` are positive
or negative if `time2` occurs after `time1`.