### PR TITLE
Add MapBasics.get()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.0]
+
+Added `MapBasics.get`.
+
 ## [0.3.0]
 
 Added `DateTimeBasics`.

--- a/lib/map_basics.dart
+++ b/lib/map_basics.dart
@@ -29,4 +29,16 @@ extension MapBasics<K, V> on Map<K, V> {
     }
     return inverted;
   }
+
+  /// A type-checked version of [operator []] that additionally supports
+  /// returning a default value.
+  ///
+  /// Returns [defaultValue] if the key is not found.  This is slightly
+  /// different from `map[key] ?? defaultValue` if the [Map] stores `null`
+  /// values.
+  //
+  // Remove if implemented upstream:
+  // https://github.com/dart-lang/sdk/issues/37392
+  V get(K key, [V defaultValue]) =>
+      this.containsKey(key) ? this[key] : defaultValue;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: basics
 description: A Dart library containing convenient extension methods on basic Dart objects.
-version: 0.3.0
+version: 0.4.0
 homepage: https://github.com/google/dart-basics
 authors:
   - johnsonmh@google.com <johnsonmh@google.com>

--- a/test/map_basics_test.dart
+++ b/test/map_basics_test.dart
@@ -33,4 +33,21 @@ void main() {
       expect(map.invert(), {});
     });
   });
+
+  group('get', () {
+    test('returns the value for a found key', () {
+      final map = {'a': 1, 'b': 2, 'c': null};
+      expect(map.get('a'), 1);
+      expect(map.get('a', 0), 1);
+
+      expect(map.get('c'), null);
+      expect(map.get('c', 0), null);
+    });
+
+    test('returns the default value if no key found', () {
+      final map = {'a': 1, 'b': 2, 'c': null};
+      expect(map.get('d'), null);
+      expect(map.get('d', 0), 0);
+    });
+  });
 }


### PR DESCRIPTION
See https://github.com/dart-lang/sdk/issues/37392

It's been a long-standing source of bugs that `Map.operator[]` is not
type-checked.  Add a `get` method that *is* type-checked.  Also use
this opportunity to allow providing a default value, similar to
Python's `dict.get`.