### PR TITLE
Add atOrBefore and atOrAfter to DateTimeBasics

### DIFF
--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -8,37 +8,37 @@ extension DateTimeBasics on DateTime {
   /// zones.
   ///
   /// Alias for [DateTime.isBefore].
-  bool operator <(DateTime other) => this.isBefore(other);
+  bool operator <(DateTime other) => isBefore(other);
 
   /// Returns true if [this] occurs strictly after [other], accounting for time
   /// zones.
   ///
   /// Alias for [DateTime.isAfter].
-  bool operator >(DateTime other) => this.isAfter(other);
+  bool operator >(DateTime other) => isAfter(other);
 
   /// Returns true if [this] occurs at or before [other], accounting for time
   /// zones.
   ///
   /// Alias for [isAtOrBefore].
-  bool operator <=(DateTime other) => this.isAtOrBefore(other);
+  bool operator <=(DateTime other) => isAtOrBefore(other);
 
   /// Returns true if [this] occurs at or after [other], accounting for time
   /// zones.
   ///
   /// Alias for [isAtOrAfter].
-  bool operator >=(DateTime other) => this.isAtOrAfter(other);
+  bool operator >=(DateTime other) => isAtOrAfter(other);
 
   /// Returns a new [DateTime] instance with [duration] added to [this].
   ///
   /// Alias for [DateTime.add].
-  DateTime operator +(Duration duration) => this.add(duration);
+  DateTime operator +(Duration duration) => add(duration);
 
   /// Returns the [Duration] between [this] and [other].
   ///
   /// The returned [Duration] will be negative if [other] occurs after [this].
   ///
   /// Alias for [DateTime.difference].
-  Duration operator -(DateTime other) => this.difference(other);
+  Duration operator -(DateTime other) => difference(other);
 
   /// Returns true if [this] occurs at or before [other], accounting for time
   /// zones.
@@ -46,13 +46,12 @@ extension DateTimeBasics on DateTime {
   /// Delegates to [DateTime]'s built-in comparison methods and therefore obeys
   /// the same contract.
   bool isAtOrBefore(DateTime other) =>
-      this.isAtSameMomentAs(other) || this.isBefore(other);
+      isAtSameMomentAs(other) || isBefore(other);
 
   /// Returns true if [this] occurs at or after [other], accounting for time
   /// zones.
   ///
   /// Delegates to [DateTime]'s built-in comparison methods and therefore obeys
   /// the same contract.
-  bool isAtOrAfter(DateTime other) =>
-      this.isAtSameMomentAs(other) || this.isAfter(other);
+  bool isAtOrAfter(DateTime other) => isAtSameMomentAs(other) || isAfter(other);
 }

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -7,40 +7,52 @@ extension DateTimeBasics on DateTime {
   /// Returns true if [this] occurs strictly before [other], accounting for time
   /// zones.
   ///
-  /// Delegates to [DateTime.compareTo] and therefore obeys the contract of that
-  /// method.
-  bool operator <(DateTime other) => compareTo(other) < 0;
+  /// Alias for [DateTime.isBefore].
+  bool operator <(DateTime other) => this.isBefore(other);
 
   /// Returns true if [this] occurs strictly after [other], accounting for time
   /// zones.
   ///
-  /// Delegates to [DateTime.compareTo] and therefore obeys the contract of that
-  /// method.
-  bool operator >(DateTime other) => compareTo(other) > 0;
+  /// Alias for [DateTime.isAfter].
+  bool operator >(DateTime other) => this.isAfter(other);
 
-  /// Returns true if [this] occurs on or before [other], accounting for time
+  /// Returns true if [this] occurs at or before [other], accounting for time
   /// zones.
   ///
-  /// Delegates to [DateTime.compareTo] and therefore obeys the contract of that
-  /// method.
-  bool operator <=(DateTime other) => compareTo(other) <= 0;
+  /// Alias for [isAtOrBefore].
+  bool operator <=(DateTime other) => this.isAtOrBefore(other);
 
-  /// Returns true if [this] occurs on or after [other], accounting for time
+  /// Returns true if [this] occurs at or after [other], accounting for time
   /// zones.
   ///
-  /// Delegates to [DateTime.compareTo] and therefore obeys the contract of that
-  /// method.
-  bool operator >=(DateTime other) => compareTo(other) >= 0;
+  /// Alias for [isAtOrAfter].
+  bool operator >=(DateTime other) => this.isAtOrAfter(other);
 
   /// Returns a new [DateTime] instance with [duration] added to [this].
   ///
-  /// Convenience alias for [DateTime.add].
+  /// Alias for [DateTime.add].
   DateTime operator +(Duration duration) => this.add(duration);
 
   /// Returns the [Duration] between [this] and [other].
   ///
   /// The returned [Duration] will be negative if [other] occurs after [this].
   ///
-  /// Convenience alias for [DateTime.difference].
+  /// Alias for [DateTime.difference].
   Duration operator -(DateTime other) => this.difference(other);
+
+  /// Returns true if [this] occurs at or before [other], accounting for time
+  /// zones.
+  ///
+  /// Delegates to [DateTime]'s built-in comparison methods and therefore obeys
+  /// the same contract.
+  bool isAtOrBefore(DateTime other) =>
+      this.isAtSameMomentAs(other) || this.isBefore(other);
+
+  /// Returns true if [this] occurs at or after [other], accounting for time
+  /// zones.
+  ///
+  /// Delegates to [DateTime]'s built-in comparison methods and therefore obeys
+  /// the same contract.
+  bool isAtOrAfter(DateTime other) =>
+      this.isAtSameMomentAs(other) || this.isAfter(other);
 }

--- a/test/date_time_basics_test.dart
+++ b/test/date_time_basics_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   final localTime = utcTime.toLocal();
 
-  group('Comparisons:', () {
+  group('comparison operators:', () {
     test('DateTime < DateTime works', () {
       expect(utcTime < utcTime, false);
       expect(utcTime < utcTimeAfter, true);
@@ -49,16 +49,40 @@ void main() {
     });
   });
 
-  test('DateTime + Duration works', () {
-    expect(utcTime + Duration(seconds: 1), utcTimeAfter);
-    expect((localTime + Duration(seconds: 1)).toUtc(), utcTimeAfter);
+  group('arithmetic operators:', () {
+    test('DateTime + Duration works', () {
+      expect(utcTime + Duration(seconds: 1), utcTimeAfter);
+      expect((localTime + Duration(seconds: 1)).toUtc(), utcTimeAfter);
 
-    expect(utcTimeAfter + -Duration(seconds: 1), utcTime);
+      expect(utcTimeAfter + -Duration(seconds: 1), utcTime);
+    });
+
+    test('DateTime - DateTime works', () {
+      expect(utcTimeAfter - utcTime, Duration(seconds: 1));
+      expect(utcTime - utcTimeAfter, -Duration(seconds: 1));
+      expect(utcTimeAfter - localTime, Duration(seconds: 1));
+    });
   });
 
-  test('DateTime - DateTime works', () {
-    expect(utcTimeAfter - utcTime, Duration(seconds: 1));
-    expect(utcTime - utcTimeAfter, -Duration(seconds: 1));
-    expect(utcTimeAfter - localTime, Duration(seconds: 1));
+  group('isAtOrBefore', () {
+    test('works as expected', () {
+      expect(utcTime.isAtOrBefore(utcTime), true);
+      expect(utcTime.isAtOrBefore(utcTimeAfter), true);
+      expect(utcTimeAfter.isAtOrBefore(utcTime), false);
+
+      expect(localTime.isAtOrBefore(utcTime), true);
+      expect(localTime.isAtOrBefore(utcTimeAfter), true);
+    });
+  });
+
+  group('isAtOrAfter', () {
+    test('works as expected', () {
+      expect(utcTime.isAtOrAfter(utcTime), true);
+      expect(utcTime.isAtOrAfter(utcTimeAfter), false);
+      expect(utcTimeAfter.isAtOrAfter(utcTime), true);
+
+      expect(localTime.isAtOrAfter(utcTime), true);
+      expect(utcTimeAfter.isAtOrAfter(localTime), true);
+    });
   });
 }


### PR DESCRIPTION
Also update the internals of DateTimeBasics to equivalent implementations that let us make clearer guarantees about contract in the dartdoc.