### PR TITLE
Update SDK Version and Fix `object_basics_test.dart`.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,6 @@ authors:
   - garciaz@google.com <garciaz@google.com>
 
 environment:
-  sdk: ">=2.10.0-0 <2.11.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 dev_dependencies:
   test: ^1.16.0-nullsafety.5

--- a/test/object_basics_test.dart
+++ b/test/object_basics_test.dart
@@ -27,7 +27,7 @@ void main() {
       List? object5;
       Map? object7;
       Set? object9;
-      var object10;
+      Object? object10;
 
       expect(object1.isNull, isTrue);
       expect(object2.isNull, isTrue);
@@ -81,7 +81,7 @@ void main() {
       List? object5;
       Map? object7;
       Set? object9;
-      var object10;
+      Object? object10;
 
       expect(object1.isNotNull, isFalse);
       expect(object2.isNotNull, isFalse);

--- a/test/object_basics_test.dart
+++ b/test/object_basics_test.dart
@@ -27,8 +27,6 @@ void main() {
       List? object5;
       Map? object7;
       Set? object9;
-      // The following line should work if written as `var object10;`,
-      // but currently it raises an error.
       Object? object10;
 
       expect(object1.isNull, isTrue);
@@ -83,8 +81,6 @@ void main() {
       List? object5;
       Map? object7;
       Set? object9;
-      // The following line should work if written as `var object10;`,
-      // but currently it raises an error.
       Object? object10;
 
       expect(object1.isNotNull, isFalse);

--- a/test/object_basics_test.dart
+++ b/test/object_basics_test.dart
@@ -27,6 +27,8 @@ void main() {
       List? object5;
       Map? object7;
       Set? object9;
+      // The following line should work if written as `var object10;`,
+      // but currently it raises an error.
       Object? object10;
 
       expect(object1.isNull, isTrue);
@@ -81,6 +83,8 @@ void main() {
       List? object5;
       Map? object7;
       Set? object9;
+      // The following line should work if written as `var object10;`,
+      // but currently it raises an error.
       Object? object10;
 
       expect(object1.isNotNull, isFalse);


### PR DESCRIPTION
This PR:
* Updates SDK version to 2.12.0-0
* Fixes a failing test in `objects_basics_test.dart`.

The failing test is equivalent to:
```dart
extension ObjectBasics on Object? {
  bool get isNull => this.runtimeType == Null;
}

void main(){
  var object10;
  print (object10.isNull);
}
```

In principle, it shouldn't fail (it succeeds on https://nullsafety.dartpad.dev/), but now it is failing.
To pass the test, we are temporarily using `Object? object10;`
We should change it back to `var object10;` after this issue is fixed for the dart language.