### PR TITLE
Add copyWith and addCalendarDays to DateTimeBasics

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -6,8 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      # TODO(johnsonmh): change this to google/dart:latest once latest supports NNBD.
-      image: google/dart:2.12-dev
+      image: google/dart:latest
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.7.0]
 
-Added `copyWith`, `addCalendarDays`, and `calendarDaysTo` to `DateTimeBasics`.
+Added `copyWith`, `addCalendarDays`, and `calendarDaysTill` to `DateTimeBasics`.
 
 ## [0.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [0.7.0]
 
-Added `copyWith` and `addCalendarDays` to `DateTimeBasics`.
+Added `copyWith`, `addCalendarDays`, and `calendarDaysTo` to `DateTimeBasics`.
 
 ## [0.6.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.0]
+
+Added `copyWith` and `addCalendarDays` to `DateTimeBasics`.
+
 ## [0.6.0]
 
 Remove object basics (`isNull` and `isNotNull`).

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -56,6 +56,8 @@ extension DateTimeBasics on DateTime {
   bool isAtOrAfter(DateTime other) => isAtSameMomentAs(other) || isAfter(other);
 
   /// Copies a [DateTime], overriding specified values.
+  ///
+  /// A UTC [DateTime] will remain in UTC; a local [DateTime] will remain local.
   DateTime copyWith({
     int? year,
     int? month,
@@ -66,27 +68,16 @@ extension DateTimeBasics on DateTime {
     int? millisecond,
     int? microsecond,
   }) {
-    return this.isUtc
-        ? DateTime.utc(
-            year ?? this.year,
-            month ?? this.month,
-            day ?? this.day,
-            hour ?? this.hour,
-            minute ?? this.minute,
-            second ?? this.second,
-            millisecond ?? this.millisecond,
-            microsecond ?? this.microsecond,
-          )
-        : DateTime(
-            year ?? this.year,
-            month ?? this.month,
-            day ?? this.day,
-            hour ?? this.hour,
-            minute ?? this.minute,
-            second ?? this.second,
-            millisecond ?? this.millisecond,
-            microsecond ?? this.microsecond,
-          );
+    return (isUtc ? DateTime.utc : DateTime.new)(
+      year ?? this.year,
+      month ?? this.month,
+      day ?? this.day,
+      hour ?? this.hour,
+      minute ?? this.minute,
+      second ?? this.second,
+      millisecond ?? this.millisecond,
+      microsecond ?? this.microsecond,
+    );
   }
 
   /// Adds a specified number of days to this [DateTime].

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -54,4 +54,48 @@ extension DateTimeBasics on DateTime {
   /// Delegates to [DateTime]'s built-in comparison methods and therefore obeys
   /// the same contract.
   bool isAtOrAfter(DateTime other) => isAtSameMomentAs(other) || isAfter(other);
+
+  /// Copies a [DateTime], overriding specified values.
+  DateTime copyWith({
+    int? year,
+    int? month,
+    int? day,
+    int? hour,
+    int? minute,
+    int? second,
+    int? millisecond,
+    int? microsecond,
+  }) {
+    return this.isUtc
+        ? DateTime.utc(
+            year ?? this.year,
+            month ?? this.month,
+            day ?? this.day,
+            hour ?? this.hour,
+            minute ?? this.minute,
+            second ?? this.second,
+            millisecond ?? this.millisecond,
+            microsecond ?? this.microsecond,
+          )
+        : DateTime(
+            year ?? this.year,
+            month ?? this.month,
+            day ?? this.day,
+            hour ?? this.hour,
+            minute ?? this.minute,
+            second ?? this.second,
+            millisecond ?? this.millisecond,
+            microsecond ?? this.microsecond,
+          );
+  }
+
+  /// Adds a specified number of days to this [DateTime].
+  ///
+  /// Unlike `DateTime.add(Duration(days: numberOfDays))`, this adds calendar
+  /// days and not 24-hour increments.  When possible, it therefore leaves the
+  /// time of day unchanged if a DST change would occur during the time
+  /// interval. (The returned time can still be different from the original if
+  /// it's valid for the returned date.)
+  DateTime addCalendarDays(int numberOfDays) =>
+      copyWith(day: day + numberOfDays);
 }

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -98,4 +98,30 @@ extension DateTimeBasics on DateTime {
   /// it's valid for the returned date.)
   DateTime addCalendarDays(int numberOfDays) =>
       copyWith(day: day + numberOfDays);
+
+  /// Returns the number of calendar days to the specified date.
+  ///
+  /// Returns a negative value if the specified date is in the past.  Ignores
+  /// the time of day.
+  ///
+  /// Example:
+  /// ```
+  /// DateTime(2020, 12, 31).calendarDaysTo(2021, 1, 1); // 1
+  /// DateTime(2020, 12, 31, 23, 59).calendarDaysTo(2021, 1, 1); // 1
+  /// ```
+  ///
+  /// This function intentionally does not take a [DateTime] argument to:
+  /// * More clearly indicate that it does not take time of day into account.
+  /// * Avoid potential problems if one [DateTime] is in UTC and the other is
+  ///   not.
+  int calendarDaysTo(int year, int month, int day) {
+    // Discard the time of day, and perform all calculations in UTC so that
+    // Daylight Saving Time adjustments are not a factor.
+    //
+    // Note that this intentionally isn't the same as `toUtc()`; we instead
+    // want to treat this `DateTime` object *as* a UTC `DateTime`.
+    final startDay = DateTime.utc(this.year, this.month, this.day);
+    final endDay = DateTime.utc(year, month, day);
+    return (endDay - startDay).inDays;
+  }
 }

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -86,26 +86,26 @@ extension DateTimeBasics on DateTime {
   /// days and not 24-hour increments.  When possible, it therefore leaves the
   /// time of day unchanged if a DST change would occur during the time
   /// interval. (The returned time can still be different from the original if
-  /// it's valid for the returned date.)
+  /// it would be invalid for the returned date.)
   DateTime addCalendarDays(int numberOfDays) =>
       copyWith(day: day + numberOfDays);
 
-  /// Returns the number of calendar days to the specified date.
+  /// Returns the number of calendar days till the specified date.
   ///
   /// Returns a negative value if the specified date is in the past.  Ignores
   /// the time of day.
   ///
   /// Example:
   /// ```
-  /// DateTime(2020, 12, 31).calendarDaysTo(2021, 1, 1); // 1
-  /// DateTime(2020, 12, 31, 23, 59).calendarDaysTo(2021, 1, 1); // 1
+  /// DateTime(2020, 12, 31).calendarDaysTill(2021, 1, 1); // 1
+  /// DateTime(2020, 12, 31, 23, 59).calendarDaysTill(2021, 1, 1); // 1
   /// ```
   ///
   /// This function intentionally does not take a [DateTime] argument to:
   /// * More clearly indicate that it does not take time of day into account.
   /// * Avoid potential problems if one [DateTime] is in UTC and the other is
   ///   not.
-  int calendarDaysTo(int year, int month, int day) {
+  int calendarDaysTill(int year, int month, int day) {
     // Discard the time of day, and perform all calculations in UTC so that
     // Daylight Saving Time adjustments are not a factor.
     //

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@
 
 name: basics
 description: A Dart library containing convenient extension methods on basic Dart objects.
-version: 0.6.0
+version: 0.7.0
 homepage: https://github.com/google/dart-basics
 authors:
   - johnsonmh@google.com <johnsonmh@google.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,6 @@ authors:
   - garciaz@google.com <garciaz@google.com>
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 dev_dependencies:
-  test: ^1.16.0-nullsafety.5
+  test: ^1.16.0

--- a/test/date_time_basics_test.dart
+++ b/test/date_time_basics_test.dart
@@ -127,23 +127,36 @@ void main() {
     });
   });
 
+  test('calendarDayTo works', () {
+    expect(DateTime(2020, 12, 31).calendarDaysTo(2021, 1, 1), 1);
+    expect(DateTime(2020, 12, 31, 23, 59).calendarDaysTo(2021, 1, 1), 1);
+    expect(DateTime(2021, 1, 1).calendarDaysTo(2020, 12, 31), -1);
+
+    expect(DateTime(2021, 3, 1).calendarDaysTo(2021, 5, 1), 31 + 30);
+    expect(DateTime(2021, 10, 1).calendarDaysTo(2021, 12, 1), 31 + 30);
+
+    expect(DateTime.utc(2020, 12, 31).calendarDaysTo(2021, 1, 1), 1);
+    expect(DateTime.utc(2020, 12, 31, 23, 59).calendarDaysTo(2021, 1, 1), 1);
+    expect(DateTime.utc(2021, 1, 1).calendarDaysTo(2020, 12, 31), -1);
+
+    expect(DateTime.utc(2021, 3, 1).calendarDaysTo(2021, 5, 1), 31 + 30);
+    expect(DateTime.utc(2021, 10, 1).calendarDaysTo(2021, 12, 1), 31 + 30);
+  });
+
   group('addCalendarDays:', () {
     // Pick an hour that is likely to always be valid.
     final startDate = DateTime(2020, 1, 1, 12, 34, 56);
 
     const daysInYear = 366; // `startDate` is in a leap year.
 
-    const paddingHours = Duration(hours: 6);
-
     test('Adds the correct number of days', () {
       for (var i = 0; i <= daysInYear; i += 1) {
         var futureDate = startDate.addCalendarDays(i);
-
-        // [Duration.inDays] returns the number of whole days (as 24-hour
-        // periods), rounded down.  Add a few hours before rounding down since
-        // `futureDate - startDate` might be less than 24 hours during DST
-        // changes.
-        expect((futureDate - startDate + paddingHours).inDays, i);
+        expect(
+          startDate.calendarDaysTo(
+              futureDate.year, futureDate.month, futureDate.day),
+          i,
+        );
       }
     });
 

--- a/test/date_time_basics_test.dart
+++ b/test/date_time_basics_test.dart
@@ -128,19 +128,19 @@ void main() {
   });
 
   test('calendarDayTo works', () {
-    expect(DateTime(2020, 12, 31).calendarDaysTo(2021, 1, 1), 1);
-    expect(DateTime(2020, 12, 31, 23, 59).calendarDaysTo(2021, 1, 1), 1);
-    expect(DateTime(2021, 1, 1).calendarDaysTo(2020, 12, 31), -1);
+    expect(DateTime(2020, 12, 31).calendarDaysTill(2021, 1, 1), 1);
+    expect(DateTime(2020, 12, 31, 23, 59).calendarDaysTill(2021, 1, 1), 1);
+    expect(DateTime(2021, 1, 1).calendarDaysTill(2020, 12, 31), -1);
 
-    expect(DateTime(2021, 3, 1).calendarDaysTo(2021, 5, 1), 31 + 30);
-    expect(DateTime(2021, 10, 1).calendarDaysTo(2021, 12, 1), 31 + 30);
+    expect(DateTime(2021, 3, 1).calendarDaysTill(2021, 5, 1), 31 + 30);
+    expect(DateTime(2021, 10, 1).calendarDaysTill(2021, 12, 1), 31 + 30);
 
-    expect(DateTime.utc(2020, 12, 31).calendarDaysTo(2021, 1, 1), 1);
-    expect(DateTime.utc(2020, 12, 31, 23, 59).calendarDaysTo(2021, 1, 1), 1);
-    expect(DateTime.utc(2021, 1, 1).calendarDaysTo(2020, 12, 31), -1);
+    expect(DateTime.utc(2020, 12, 31).calendarDaysTill(2021, 1, 1), 1);
+    expect(DateTime.utc(2020, 12, 31, 23, 59).calendarDaysTill(2021, 1, 1), 1);
+    expect(DateTime.utc(2021, 1, 1).calendarDaysTill(2020, 12, 31), -1);
 
-    expect(DateTime.utc(2021, 3, 1).calendarDaysTo(2021, 5, 1), 31 + 30);
-    expect(DateTime.utc(2021, 10, 1).calendarDaysTo(2021, 12, 1), 31 + 30);
+    expect(DateTime.utc(2021, 3, 1).calendarDaysTill(2021, 5, 1), 31 + 30);
+    expect(DateTime.utc(2021, 10, 1).calendarDaysTill(2021, 12, 1), 31 + 30);
   });
 
   group('addCalendarDays:', () {
@@ -153,7 +153,7 @@ void main() {
       for (var i = 0; i <= daysInYear; i += 1) {
         var futureDate = startDate.addCalendarDays(i);
         expect(
-          startDate.calendarDaysTo(
+          startDate.calendarDaysTill(
               futureDate.year, futureDate.month, futureDate.day),
           i,
         );

--- a/test/date_time_basics_test.dart
+++ b/test/date_time_basics_test.dart
@@ -85,4 +85,100 @@ void main() {
       expect(utcTimeAfter.isAtOrAfter(localTime), true);
     });
   });
+
+  group('copyWith:', () {
+    test('Copies existing values', () {
+      var copy = utcTime.copyWith();
+      expect(utcTime, isNot(same(copy)));
+      expect(utcTime, copy);
+
+      copy = localTime.copyWith();
+      expect(localTime, isNot(same(copy)));
+      expect(localTime, copy);
+    });
+
+    test('Overrides existing values', () {
+      final utcOverrides = DateTime.utc(2000, 1, 2, 3, 4, 5, 6, 7);
+      final localOverrides = utcOverrides.toLocal();
+
+      var copy = utcTime.copyWith(
+        year: utcOverrides.year,
+        month: utcOverrides.month,
+        day: utcOverrides.day,
+        hour: utcOverrides.hour,
+        minute: utcOverrides.minute,
+        second: utcOverrides.second,
+        millisecond: utcOverrides.millisecond,
+        microsecond: utcOverrides.microsecond,
+      );
+      expect(copy, utcOverrides);
+
+      copy = localTime.copyWith(
+        year: localOverrides.year,
+        month: localOverrides.month,
+        day: localOverrides.day,
+        hour: localOverrides.hour,
+        minute: localOverrides.minute,
+        second: localOverrides.second,
+        millisecond: localOverrides.millisecond,
+        microsecond: localOverrides.microsecond,
+      );
+      expect(copy, localOverrides);
+    });
+  });
+
+  group('addCalendarDays:', () {
+    // Pick an hour that is likely to always be valid.
+    final startDate = DateTime(2020, 1, 1, 12, 34, 56);
+
+    const daysInYear = 366; // `startDate` is in a leap year.
+
+    const paddingHours = Duration(hours: 6);
+
+    test('Adds the correct number of days', () {
+      for (var i = 0; i <= daysInYear; i += 1) {
+        var futureDate = startDate.addCalendarDays(i);
+
+        // [Duration.inDays] returns the number of whole days (as 24-hour
+        // periods), rounded down.  Add a few hours before rounding down since
+        // `futureDate - startDate` might be less than 24 hours during DST
+        // changes.
+        expect((futureDate - startDate + paddingHours).inDays, i);
+      }
+    });
+
+    test('Preserves time of day', () {
+      for (var i = 0; i <= daysInYear; i += 1) {
+        var futureDate = startDate.addCalendarDays(i);
+        expect(
+          [futureDate.hour, futureDate.minute, futureDate.second],
+          [startDate.hour, startDate.minute, startDate.second],
+        );
+      }
+
+      // This test is unfortunately dependent on the local timezone and is not
+      // meaningful if the local timezone does not observe daylight saving time.
+    }, skip: !_observesDaylightSaving());
+  });
+}
+
+/// Tries to empirically determine if the local timezone observes daylight
+/// saving time changes.
+///
+/// We can't control the local timezone used by [DateTime] in tests, so we have
+/// to guess.
+bool _observesDaylightSaving() {
+  final startDate = DateTime(2020, 1, 1, 12, 0);
+  var localDate = startDate.copyWith();
+
+  const oneDay = Duration(days: 1);
+  while (localDate.year < startDate.year + 1) {
+    localDate = localDate.add(oneDay);
+    if (localDate.hour != startDate.hour ||
+        localDate.minute != startDate.minute ||
+        localDate.second != startDate.second) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
As evidenced by a number of questions on StackOverflow, it's not
uncommon for people to want to perform date calculations with
logical, calendar days instead of with 24-hour increments.  They then
often get confused about why their code computes slightly unexpected
times at certain points of the year (and not noticing that those
points span DST changes).  Add an `addCalendarDays` extension method.

There also are a number of cases where copying a `DateTime` would be
useful, but doing so is tedious since a general function to copy a
`DateTime` needs separate code paths for UTC and non-UTC `DateTime`
objects.  Add a `copyWith` extension method, which also is useful for
implementing `addCalendarDays`.