### PR TITLE
Add cache to maxBy and minBy

### DIFF
--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -114,6 +114,9 @@ extension IterableBasics<E> on Iterable<E> {
   /// Returns the element of [this] with the greatest value for [sortKey], or
   /// [null] if [this] is empty.
   ///
+  /// This method is guaranteed to calculate [sortKey] only once for each
+  /// element.
+  ///
   /// Example:
   /// ```dart
   /// ['a', 'aaa', 'aa'].maxBy((e) => e.length).value; // 'aaa'
@@ -125,6 +128,9 @@ extension IterableBasics<E> on Iterable<E> {
 
   /// Returns the element of [this] with the least value for [sortKey], or
   /// [null] if [this] is empty.
+  ///
+  /// This method is guaranteed to calculate [sortKey] only once for each
+  /// element.
   ///
   /// Example:
   /// ```dart

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -4,6 +4,8 @@
 
 import 'dart:math' as math;
 
+import 'src/sort_key_compare.dart';
+
 /// Utility extension methods for the native [Iterable] class.
 extension IterableBasics<E> on Iterable<E> {
   /// Alias for [Iterable]`.every`.
@@ -118,8 +120,7 @@ extension IterableBasics<E> on Iterable<E> {
   /// ```
   E? maxBy(Comparable Function(E) sortKey) {
     final sortKeyCache = <E, Comparable>{};
-    return this.max((a, b) =>
-        _compareToWithSortKeyAndCache<E>(a, b, sortKey, sortKeyCache));
+    return this.max((a, b) => sortKeyCompare<E>(a, b, sortKey, sortKeyCache));
   }
 
   /// Returns the element of [this] with the least value for [sortKey], or
@@ -131,8 +132,7 @@ extension IterableBasics<E> on Iterable<E> {
   /// ```
   E? minBy(Comparable Function(E) sortKey) {
     final sortKeyCache = <E, Comparable>{};
-    return this.min((a, b) =>
-        _compareToWithSortKeyAndCache<E>(a, b, sortKey, sortKeyCache));
+    return this.min((a, b) => sortKeyCompare<E>(a, b, sortKey, sortKeyCache));
   }
 
   /// Returns the sum of all the values in this iterable, as defined by
@@ -243,19 +243,4 @@ Map<E, int> _elementCountsIn<E>(Iterable<E> iterable) {
     counts[element] = currentCount + 1;
   }
   return counts;
-}
-
-int _compareToWithSortKeyAndCache<T>(
-    T a, T b, Comparable Function(T) sortKey, Map<T, Comparable> sortKeyCache) {
-  // Can't use putIfAbsent because that will evaluate sortKey every time,
-  // which defeats the point of using a cache.
-  final keyA = sortKeyCache[a] ?? sortKey(a);
-  final keyB = sortKeyCache[b] ?? sortKey(b);
-  if (!sortKeyCache.containsKey(a)) {
-    sortKeyCache[a] = keyA;
-  }
-  if (!sortKeyCache.containsKey(b)) {
-    sortKeyCache[b] = keyB;
-  }
-  return keyA.compareTo(keyB);
 }

--- a/lib/list_basics.dart
+++ b/lib/list_basics.dart
@@ -88,6 +88,9 @@ extension ListBasics<E> on List<E> {
 
   /// Sorts this list by the value returned by [sortKey] for each element.
   ///
+  /// This method is guaranteed to calculate [sortKey] only once for each
+  /// element.
+  ///
   /// Example:
   /// ```dart
   /// var list = [-12, 3, 10];
@@ -100,6 +103,9 @@ extension ListBasics<E> on List<E> {
 
   /// Returns a copy of this list sorted by the value returned by [sortKey] for
   /// each element.
+  ///
+  /// This method is guaranteed to calculate [sortKey] only once for each
+  /// element.
   ///
   /// Example:
   /// ```dart

--- a/lib/list_basics.dart
+++ b/lib/list_basics.dart
@@ -5,6 +5,7 @@
 import 'dart:math' as math;
 
 import 'src/slice_indices.dart';
+import 'src/sort_key_compare.dart';
 
 /// Utility extension methods for the native [List] class.
 extension ListBasics<E> on List<E> {
@@ -93,7 +94,8 @@ extension ListBasics<E> on List<E> {
   /// list.sortBy((e) => e.toString().length); // list is now [3, 10, -12].
   /// ```
   void sortBy(Comparable Function(E) sortKey) {
-    this.sort((a, b) => sortKey(a).compareTo(sortKey(b)));
+    final sortKeyCache = <E, Comparable>{};
+    this.sort((a, b) => sortKeyCompare(a, b, sortKey, sortKeyCache));
   }
 
   /// Returns a copy of this list sorted by the value returned by [sortKey] for

--- a/lib/src/sort_key_compare.dart
+++ b/lib/src/sort_key_compare.dart
@@ -1,0 +1,28 @@
+// Copyright (c) 2022, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Shared logic for ordering and sorting methods that compare their operands
+/// using a calculated [sortKey].
+///
+/// This method obeys the contract of [Comparable].`compareTo`, except by
+/// comparing `sortKey(a)` and `sortKey(b)`, rather than [a] and [b].
+///
+/// Note that the caller must provide a cache, to avoid repeatedly computing
+/// the same [sortKey] values. This cache will be mutated by this function.
+/// It is expected that all calls to this function within a single ordering
+/// or sorting will provide the same cache instance with each call.
+int sortKeyCompare<T>(
+    T a, T b, Comparable Function(T) sortKey, Map<T, Comparable> sortKeyCache) {
+  // Can't use putIfAbsent because that will evaluate sortKey every time,
+  // which defeats the point of using a cache.
+  final keyA = sortKeyCache[a] ?? sortKey(a);
+  final keyB = sortKeyCache[b] ?? sortKey(b);
+  if (!sortKeyCache.containsKey(a)) {
+    sortKeyCache[a] = keyA;
+  }
+  if (!sortKeyCache.containsKey(b)) {
+    sortKeyCache[b] = keyB;
+  }
+  return keyA.compareTo(keyB);
+}

--- a/lib/src/sort_key_compare.dart
+++ b/lib/src/sort_key_compare.dart
@@ -14,15 +14,8 @@
 /// or sorting will provide the same cache instance with each call.
 int sortKeyCompare<T>(
     T a, T b, Comparable Function(T) sortKey, Map<T, Comparable> sortKeyCache) {
-  // Can't use putIfAbsent because that will evaluate sortKey every time,
-  // which defeats the point of using a cache.
-  final keyA = sortKeyCache[a] ?? sortKey(a);
-  final keyB = sortKeyCache[b] ?? sortKey(b);
-  if (!sortKeyCache.containsKey(a)) {
-    sortKeyCache[a] = keyA;
-  }
-  if (!sortKeyCache.containsKey(b)) {
-    sortKeyCache[b] = keyB;
-  }
-  return keyA.compareTo(keyB);
+  sortKeyCache[a] ??= sortKey(a);
+  sortKeyCache[b] ??= sortKey(b);
+  // Since both values were just set, safe to ignore null here.
+  return sortKeyCache[a]!.compareTo(sortKeyCache[b]!);
 }

--- a/lib/src/sort_key_compare.dart
+++ b/lib/src/sort_key_compare.dart
@@ -14,8 +14,7 @@
 /// or sorting will provide the same cache instance with each call.
 int sortKeyCompare<T>(
     T a, T b, Comparable Function(T) sortKey, Map<T, Comparable> sortKeyCache) {
-  sortKeyCache[a] ??= sortKey(a);
-  sortKeyCache[b] ??= sortKey(b);
-  // Since both values were just set, safe to ignore null here.
-  return sortKeyCache[a]!.compareTo(sortKeyCache[b]!);
+  final keyA = sortKeyCache.putIfAbsent(a, () => sortKey(a));
+  final keyB = sortKeyCache.putIfAbsent(b, () => sortKey(b));
+  return keyA.compareTo(keyB);
 }

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -349,6 +349,24 @@ void main() {
       expect(emptyInts.maxBy((a) => a.toString().length), isNull);
       expect(emptyStrings.maxBy((a) => a.length), isNull);
     });
+
+    test('does not calculate any sort key more than once', () {
+      final values = [3, 222, 11, 15, 18];
+
+      final callCounts = <int, int>{};
+      int recordCallAndReturn(int e) {
+        callCounts.putIfAbsent(e, () => 0);
+        callCounts[e] = callCounts[e]! + 1;
+        return e;
+      }
+
+      final result = values.maxBy((e) => recordCallAndReturn(e));
+
+      expect(result, 222);
+      expect(callCounts.length, 5);
+      expect(callCounts.keys.toSet(), values.toSet());
+      expect(callCounts.values.every((e) => e == 1), isTrue);
+    });
   });
 
   group('minBy', () {
@@ -370,6 +388,24 @@ void main() {
 
       expect(emptyInts.minBy((a) => a.toString().length), isNull);
       expect(emptyStrings.minBy((a) => a.length), isNull);
+    });
+
+    test('does not calculate any sort key more than once', () {
+      final values = [3, 222, 11, 15, 18];
+
+      final callCounts = <int, int>{};
+      int recordCallAndReturn(int e) {
+        callCounts.putIfAbsent(e, () => 0);
+        callCounts[e] = callCounts[e]! + 1;
+        return e;
+      }
+
+      final result = values.minBy((e) => recordCallAndReturn(e));
+
+      expect(result, 3);
+      expect(callCounts.length, 5);
+      expect(callCounts.keys.toSet(), values.toSet());
+      expect(callCounts.values.every((e) => e == 1), isTrue);
     });
   });
 

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -351,7 +351,7 @@ void main() {
     });
 
     test('does not calculate any sort key more than once', () {
-      final values = [3, 222, 11, 15, 18];
+      final values = [3, 222, 3, 15, 18];
 
       final callCounts = <int, int>{};
       int recordCallAndReturn(int e) {
@@ -362,7 +362,7 @@ void main() {
       final result = values.maxBy((e) => recordCallAndReturn(e));
 
       expect(result, 222);
-      expect(callCounts.length, 5);
+      expect(callCounts.length, values.toSet().length);
       expect(callCounts.keys.toSet(), values.toSet());
       expect(callCounts.values.every((e) => e == 1), isTrue);
     });
@@ -390,7 +390,7 @@ void main() {
     });
 
     test('does not calculate any sort key more than once', () {
-      final values = [3, 222, 11, 15, 18];
+      final values = [3, 222, 3, 15, 18];
 
       final callCounts = <int, int>{};
       int recordCallAndReturn(int e) {
@@ -401,7 +401,7 @@ void main() {
       final result = values.minBy((e) => recordCallAndReturn(e));
 
       expect(result, 3);
-      expect(callCounts.length, 5);
+      expect(callCounts.length, values.toSet().length);
       expect(callCounts.keys.toSet(), values.toSet());
       expect(callCounts.values.every((e) => e == 1), isTrue);
     });

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -355,8 +355,7 @@ void main() {
 
       final callCounts = <int, int>{};
       int recordCallAndReturn(int e) {
-        callCounts.putIfAbsent(e, () => 0);
-        callCounts[e] = callCounts[e]! + 1;
+        callCounts.update(e, (value) => value++, ifAbsent: () => 1);
         return e;
       }
 
@@ -395,8 +394,7 @@ void main() {
 
       final callCounts = <int, int>{};
       int recordCallAndReturn(int e) {
-        callCounts.putIfAbsent(e, () => 0);
-        callCounts[e] = callCounts[e]! + 1;
+        callCounts.update(e, (value) => value++, ifAbsent: () => 1);
         return e;
       }
 

--- a/test/list_basics_test.dart
+++ b/test/list_basics_test.dart
@@ -207,8 +207,7 @@ void main() {
 
       final callCounts = <int, int>{};
       int recordCallAndReturn(int e) {
-        callCounts.putIfAbsent(e, () => 0);
-        callCounts[e] = callCounts[e]! + 1;
+        callCounts.update(e, (value) => value++, ifAbsent: () => 1);
         return e;
       }
 
@@ -234,8 +233,7 @@ void main() {
 
       final callCounts = <int, int>{};
       int recordCallAndReturn(int e) {
-        callCounts.putIfAbsent(e, () => 0);
-        callCounts[e] = callCounts[e]! + 1;
+        callCounts.update(e, (value) => value++, ifAbsent: () => 1);
         return e;
       }
 

--- a/test/list_basics_test.dart
+++ b/test/list_basics_test.dart
@@ -203,7 +203,7 @@ void main() {
     });
 
     test('does not calculate any sort key more than once', () {
-      final values = [3, 222, 11, 15, 18];
+      final values = [3, 222, 3, 15, 18];
 
       final callCounts = <int, int>{};
       int recordCallAndReturn(int e) {
@@ -213,8 +213,8 @@ void main() {
 
       values.sortBy((e) => recordCallAndReturn(e));
 
-      expect(values, [3, 11, 15, 18, 222]);
-      expect(callCounts.length, 5);
+      expect(values, [3, 3, 15, 18, 222]);
+      expect(callCounts.length, values.toSet().length);
       expect(callCounts.keys.toSet(), values.toSet());
       expect(callCounts.values.every((e) => e == 1), isTrue);
     });
@@ -229,7 +229,7 @@ void main() {
     });
 
     test('does not calculate any sort key more than once', () {
-      final original = [3, 222, 11, 15, 18];
+      final original = [3, 222, 3, 15, 18];
 
       final callCounts = <int, int>{};
       int recordCallAndReturn(int e) {
@@ -239,8 +239,8 @@ void main() {
 
       final sortedCopy = original.sortedCopyBy((e) => recordCallAndReturn(e));
 
-      expect(sortedCopy, [3, 11, 15, 18, 222]);
-      expect(callCounts.length, 5);
+      expect(sortedCopy, [3, 3, 15, 18, 222]);
+      expect(callCounts.length, original.toSet().length);
       expect(callCounts.keys.toSet(), original.toSet());
       expect(callCounts.values.every((e) => e == 1), isTrue);
     });

--- a/test/list_basics_test.dart
+++ b/test/list_basics_test.dart
@@ -201,6 +201,24 @@ void main() {
       expect(listA, [3, 11, 222]);
       expect(listB, [11, 222, 3]);
     });
+
+    test('does not calculate any sort key more than once', () {
+      final values = [3, 222, 11, 15, 18];
+
+      final callCounts = <int, int>{};
+      int recordCallAndReturn(int e) {
+        callCounts.putIfAbsent(e, () => 0);
+        callCounts[e] = callCounts[e]! + 1;
+        return e;
+      }
+
+      values.sortBy((e) => recordCallAndReturn(e));
+
+      expect(values, [3, 11, 15, 18, 222]);
+      expect(callCounts.length, 5);
+      expect(callCounts.keys.toSet(), values.toSet());
+      expect(callCounts.values.every((e) => e == 1), isTrue);
+    });
   });
 
   group('sortedCopyBy', () {
@@ -209,6 +227,24 @@ void main() {
       final sortedCopy = original.sortedCopyBy((e) => e.toString());
       expect(original, [3, 222, 11]);
       expect(sortedCopy, [11, 222, 3]);
+    });
+
+    test('does not calculate any sort key more than once', () {
+      final original = [3, 222, 11, 15, 18];
+
+      final callCounts = <int, int>{};
+      int recordCallAndReturn(int e) {
+        callCounts.putIfAbsent(e, () => 0);
+        callCounts[e] = callCounts[e]! + 1;
+        return e;
+      }
+
+      final sortedCopy = original.sortedCopyBy((e) => recordCallAndReturn(e));
+
+      expect(sortedCopy, [3, 11, 15, 18, 222]);
+      expect(callCounts.length, 5);
+      expect(callCounts.keys.toSet(), original.toSet());
+      expect(callCounts.values.every((e) => e == 1), isTrue);
     });
   });
 


### PR DESCRIPTION
Currently, maxBy and minBy call sortKey on both elements for every comparison. However, since a given element will be involved in multiple sequential comparisons, and we're assuming sortKey returns the same value for every invocation on a given element (since if that's not true, having a max or min by that key is undefined), we should really only be calculating the sortKey value for a given element once, in case sortKey is expensive to compute.

To resolve this, this PR updates maxBy and minBy to cache sortKey values once they're computed.

This resolves issue #32.