### PR TITLE
Add isNullOrBlank and isNotNullOrBlank

### DIFF
--- a/lib/string_basics.dart
+++ b/lib/string_basics.dart
@@ -201,3 +201,13 @@ extension StringBasics on String {
     return stringBuffer.toString();
   }
 }
+
+extension NullableStringBasics on String? {
+  /// Returns `true` if [this] is null, empty, or consists solely of
+  /// whitespace characters as defined by [String.trim].
+  bool get isNullOrBlank => this?.trim()?.isEmpty ?? true;
+
+  /// Returns `true` if [this] is not null, not empty, and does not consist
+  /// solely of whitespace characters as defined by [String.trim].
+  bool get isNotNullOrBlank => this?.trim()?.isNotEmpty ?? false;
+}

--- a/test/string_basics_test.dart
+++ b/test/string_basics_test.dart
@@ -302,4 +302,54 @@ void main() {
       expect(''.reverse(), '');
     });
   });
+
+  group('isBlank', () {
+    test('returns true if a string is blank', () {
+      expect(''.isBlank, isTrue);
+    });
+
+    test('returns false if a string is not blank', () {
+      expect('a'.isBlank, isFalse);
+    });
+  });
+
+  group('isNotBlank', () {
+    test('returns false if a string is blank', () {
+      expect(''.isNotBlank, isFalse);
+    });
+
+    test('returns true if a string is not blank', () {
+      expect('a'.isNotBlank, isTrue);
+    });
+  });
+
+  group('isNullOrBlank', () {
+    test('returns true if a string is null', () {
+      final String? string = null;
+      expect(string.isNullOrBlank, isTrue);
+    });
+
+    test('returns true if a string is blank', () {
+      expect(''.isNullOrBlank, isTrue);
+    });
+
+    test('returns false if a string is not blank', () {
+      expect('a'.isNullOrBlank, isFalse);
+    });
+  });
+
+  group('isNotNullOrBlank', () {
+    test('returns false if a string is null', () {
+      final String? string = null;
+      expect(string.isNotNullOrBlank, isFalse);
+    });
+
+    test('returns false if a string is blank', () {
+      expect(''.isNotNullOrBlank, isFalse);
+    });
+
+    test('returns true if a string is not blank', () {
+      expect('a'.isNotNullOrBlank, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
Before the null safety migration, `StringBasics#isBlank` and `#isNotBlank` both allowed a null receiver, treating it as blank. After the null safety migration, since the extension methods were defined on `String` and not `String?`, they could no longer be called on a null receiver, making them less useful. This PR resolves that issue.

I considered just moving the existing methods to a `String?` extension class and keeping the same behavior as before. However, given that the null safety migration has made being aware of null values more important across Dart code in general, I opted for being extremely unambiguous with the naming so a user won't have to guess about the behavior, and added two new methods that explicitly call out in the name that they handle nulls, while leaving the existing methods untouched.

I also added tests to explicitly define the contract for all four methods.

This resolves issue #35.