### PR TITLE
Add range method to Iterable

### DIFF
--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -150,23 +150,20 @@ extension IterableBasics<E> on Iterable<E> {
       ? null
       : this.elementAt(math.Random(seed).nextInt(this.length));
 
-  /// Returns an [Iterable] containing the first [to] elements of [this],
-  /// excluding the first [from] elements.
+  /// Returns an [Iterable] containing the first [end] elements of [this],
+  /// excluding the first [start] elements.
   ///
-  /// If [from] is greater than or equal to the number of elements available
-  /// in [this], this method will return an empty [Iterable].
-  ///
-  /// If [to] is greater than the number of elements available in [this],
-  /// this method will return all available elements from [from] to the
-  /// end of [this].
+  /// This method is a generalization of [List.getRange] to [Iterable]s,
+  /// and obeys the same contract.
   ///
   /// Example:
   /// ```dart
-  /// [3, 8, 12, 4, 1].range(2, 4); // [12, 4]
-  /// [3, 8, 12, 4, 1].range(6, 8); // []
-  /// [3, 8, 12, 4, 1].range(3, 10); // [4, 1]
+  /// {3, 8, 12, 4, 1}.range(2, 4); // [12, 4]
   /// ```
-  Iterable<E> range(int from, int to) => this.skip(from).take(to - from);
+  Iterable<E> getRange(int start, int end) {
+    RangeError.checkValidRange(start, end, this.length);
+    return this.skip(start).take(end - start);
+  }
 }
 
 /// Utility extension methods for [Iterable]s containing [num]s.

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -136,7 +136,7 @@ extension IterableBasics<E> on Iterable<E> {
   ///
   /// Example:
   /// ```dart
-  /// ['a', 'aa', 'aaa'].sum((s) => s.length); // 6.
+  /// ['a', 'aa', 'aaa'].sum((s) => s.length); // 6
   /// ```
   num sum(num Function(E) addend) => this.isEmpty
       ? 0
@@ -149,6 +149,24 @@ extension IterableBasics<E> on Iterable<E> {
   E? getRandom({int? seed}) => this.isEmpty
       ? null
       : this.elementAt(math.Random(seed).nextInt(this.length));
+
+  /// Returns an [Iterable] containing the first [to] elements of [this],
+  /// excluding the first [from] elements.
+  ///
+  /// If [from] is greater than or equal to the number of elements available
+  /// in [this], this method will return an empty [Iterable].
+  ///
+  /// If [to] is greater than the number of elements available in [this],
+  /// this method will return all available elements from [from] to the
+  /// end of [this].
+  ///
+  /// Example:
+  /// ```dart
+  /// [3, 8, 12, 4, 1].range(2, 4); // [12, 4]
+  /// [3, 8, 12, 4, 1].range(6, 8); // []
+  /// [3, 8, 12, 4, 1].range(3, 10); // [4, 1]
+  /// ```
+  Iterable<E> range(int from, int to) => this.skip(from).take(to - from);
 }
 
 /// Utility extension methods for [Iterable]s containing [num]s.

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -427,23 +427,50 @@ void main() {
     });
   });
 
-  group('range', () {
+  group('getRange', () {
     test('returns a range from an iterable', () {
-      final values = [3, 8, 12, 4, 1];
-      expect(values.range(2, 4), [12, 4]);
-      expect(values.range(0, 2), [3, 8]);
-      expect(values.range(3, 5), [4, 1]);
-      expect(values.range(3, 3), []);
+      final values = {3, 8, 12, 4, 1};
+      expect(values.getRange(2, 4), [12, 4]);
+      expect(values.getRange(0, 2), [3, 8]);
+      expect(values.getRange(3, 5), [4, 1]);
+      expect(values.getRange(3, 3), []);
+      expect(values.getRange(5, 5), []);
     });
 
-    test('returns empty when from is greater than number of elements', () {
-      final values = [3, 8, 12, 4, 1];
-      expect(values.range(5, 8), []);
+    test('matches the behavior of List#getRange', () {
+      final iterableValues = {3, 8, 12, 4, 1};
+      final listValues = [3, 8, 12, 4, 1];
+      expect(iterableValues.getRange(2, 4), listValues.getRange(2, 4));
+      expect(iterableValues.getRange(0, 2), listValues.getRange(0, 2));
+      expect(iterableValues.getRange(3, 5), listValues.getRange(3, 5));
+      expect(iterableValues.getRange(3, 3), listValues.getRange(3, 3));
+      expect(iterableValues.getRange(5, 5), listValues.getRange(5, 5));
     });
 
-    test('returns to end when to is greater than number of elements', () {
-      final values = [3, 8, 12, 4, 1];
-      expect(values.range(3, 10), [4, 1]);
+    test('throws error when start > number of elements', () {
+      final values = {3, 8, 12, 4, 1};
+      expect(() => values.getRange(6, 7), throwsRangeError);
+    });
+
+    test('matches List#getRange when start > number of elements', () {
+      final iterableValues = {3, 8, 12, 4, 1};
+      final listValues = [3, 8, 12, 4, 1];
+      final iterableError = _getRangeError(() => iterableValues.getRange(6, 7));
+      final listError = _getRangeError(() => listValues.getRange(6, 7));
+      _expectRangeErrorMatches(iterableError, listError);
+    });
+
+    test('throws error when end > number of elements', () {
+      final values = {3, 8, 12, 4, 1};
+      expect(() => values.getRange(4, 8), throwsRangeError);
+    });
+
+    test('matches List#getRange when end > number of elements', () {
+      final iterableValues = {3, 8, 12, 4, 1};
+      final listValues = [3, 8, 12, 4, 1];
+      final iterableError = _getRangeError(() => iterableValues.getRange(4, 8));
+      final listError = _getRangeError(() => listValues.getRange(4, 8));
+      _expectRangeErrorMatches(iterableError, listError);
     });
   });
 }
@@ -452,4 +479,20 @@ num _getItemSize(dynamic item) {
   if (item is num) return item;
   if (item is String) return item.length;
   throw UnimplementedError();
+}
+
+RangeError _getRangeError(Iterable Function() f) {
+  try {
+    f();
+  } on RangeError catch (e) {
+    return e;
+  }
+  throw AssertionError("Expected RangeError but none was thrown");
+}
+
+void _expectRangeErrorMatches(RangeError actual, RangeError expected) {
+  expect(actual.start, expected.start);
+  expect(actual.end, expected.end);
+  expect(actual.name, expected.name);
+  expect(actual.message, expected.message);
 }

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -426,6 +426,26 @@ void main() {
       expect(['a', 'b', 'c', 'd'].getRandom(seed: 45), 'c');
     });
   });
+
+  group('range', () {
+    test('returns a range from an iterable', () {
+      final values = [3, 8, 12, 4, 1];
+      expect(values.range(2, 4), [12, 4]);
+      expect(values.range(0, 2), [3, 8]);
+      expect(values.range(3, 5), [4, 1]);
+      expect(values.range(3, 3), []);
+    });
+
+    test('returns empty when from is greater than number of elements', () {
+      final values = [3, 8, 12, 4, 1];
+      expect(values.range(5, 8), []);
+    });
+
+    test('returns to end when to is greater than number of elements', () {
+      final values = [3, 8, 12, 4, 1];
+      expect(values.range(3, 10), [4, 1]);
+    });
+  });
 }
 
 num _getItemSize(dynamic item) {


### PR DESCRIPTION
This adds a `range` method to `Iterable`, e.g.:

[3, 4, 8, 12, 2].range(4, 2) => [8, 12]

This resolves issue #23.