### PR TITLE
Enable stricter type checks

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -11,7 +11,14 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        sdk: [2.17.0, stable, dev]
+
+    name: build on ${{ matrix.os }} for ${{ matrix.sdk }}
 
     steps:
       - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.9.0]
+
+* Added stricter type checks.
+
 ## [0.8.0]
 
 * Added `ComparableBasics`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.9.0]
+## [0.8.1]
 
 * Added stricter type checks.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,10 @@
 include: package:pedantic/analysis_options.1.8.0.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: true
-    implicit-dynamic: true
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
 linter:
   rules:

--- a/example/main.dart
+++ b/example/main.dart
@@ -4,7 +4,7 @@
 
 import 'package:basics/basics.dart';
 
-main() async {
+void main() async {
   const numbers = <int>[2, 4, 8];
 
   if (numbers.all((n) => n.isEven)) {
@@ -15,6 +15,6 @@ main() async {
 
   for (var _ in 5.range) {
     print('waiting 500 milliseconds...');
-    await Future.delayed(500.milliseconds);
+    await Future<void>.delayed(500.milliseconds);
   }
 }

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -121,8 +121,8 @@ extension IterableBasics<E> on Iterable<E> {
   /// ```dart
   /// ['a', 'aaa', 'aa'].maxBy((e) => e.length).value; // 'aaa'
   /// ```
-  E? maxBy(Comparable<Object?> Function(E) sortKey) {
-    final sortKeyCache = <E, Comparable<Object?>>{};
+  E? maxBy(Comparable<dynamic> Function(E) sortKey) {
+    final sortKeyCache = <E, Comparable<dynamic>>{};
     return this.max((a, b) => sortKeyCompare<E>(a, b, sortKey, sortKeyCache));
   }
 
@@ -136,8 +136,8 @@ extension IterableBasics<E> on Iterable<E> {
   /// ```dart
   /// ['a', 'aaa', 'aa'].minBy((e) => e.length).value; // 'a'
   /// ```
-  E? minBy(Comparable<Object?> Function(E) sortKey) {
-    final sortKeyCache = <E, Comparable<Object?>>{};
+  E? minBy(Comparable<dynamic> Function(E) sortKey) {
+    final sortKeyCache = <E, Comparable<dynamic>>{};
     return this.min((a, b) => sortKeyCompare<E>(a, b, sortKey, sortKeyCache));
   }
 

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -121,8 +121,8 @@ extension IterableBasics<E> on Iterable<E> {
   /// ```dart
   /// ['a', 'aaa', 'aa'].maxBy((e) => e.length).value; // 'aaa'
   /// ```
-  E? maxBy(Comparable Function(E) sortKey) {
-    final sortKeyCache = <E, Comparable>{};
+  E? maxBy(Comparable<Object?> Function(E) sortKey) {
+    final sortKeyCache = <E, Comparable<Object?>>{};
     return this.max((a, b) => sortKeyCompare<E>(a, b, sortKey, sortKeyCache));
   }
 
@@ -136,8 +136,8 @@ extension IterableBasics<E> on Iterable<E> {
   /// ```dart
   /// ['a', 'aaa', 'aa'].minBy((e) => e.length).value; // 'a'
   /// ```
-  E? minBy(Comparable Function(E) sortKey) {
-    final sortKeyCache = <E, Comparable>{};
+  E? minBy(Comparable<Object?> Function(E) sortKey) {
+    final sortKeyCache = <E, Comparable<Object?>>{};
     return this.min((a, b) => sortKeyCompare<E>(a, b, sortKey, sortKeyCache));
   }
 

--- a/lib/list_basics.dart
+++ b/lib/list_basics.dart
@@ -96,8 +96,8 @@ extension ListBasics<E> on List<E> {
   /// var list = [-12, 3, 10];
   /// list.sortBy((e) => e.toString().length); // list is now [3, 10, -12].
   /// ```
-  void sortBy(Comparable Function(E) sortKey) {
-    final sortKeyCache = <E, Comparable>{};
+  void sortBy(Comparable<Object?> Function(E) sortKey) {
+    final sortKeyCache = <E, Comparable<Object?>>{};
     this.sort((a, b) => sortKeyCompare(a, b, sortKey, sortKeyCache));
   }
 
@@ -113,7 +113,7 @@ extension ListBasics<E> on List<E> {
   /// var sorted = list.sortedCopyBy((e) => e.toString().length);
   /// // list is still [-12, 3, 10]. sorted is [3, 10, -12].
   /// ```
-  List<E> sortedCopyBy(Comparable Function(E) sortKey) {
+  List<E> sortedCopyBy(Comparable<Object?> Function(E) sortKey) {
     return List<E>.of(this)..sortBy(sortKey);
   }
 

--- a/lib/list_basics.dart
+++ b/lib/list_basics.dart
@@ -96,8 +96,8 @@ extension ListBasics<E> on List<E> {
   /// var list = [-12, 3, 10];
   /// list.sortBy((e) => e.toString().length); // list is now [3, 10, -12].
   /// ```
-  void sortBy(Comparable<Object?> Function(E) sortKey) {
-    final sortKeyCache = <E, Comparable<Object?>>{};
+  void sortBy(Comparable<dynamic> Function(E) sortKey) {
+    final sortKeyCache = <E, Comparable<dynamic>>{};
     this.sort((a, b) => sortKeyCompare(a, b, sortKey, sortKeyCache));
   }
 
@@ -113,7 +113,7 @@ extension ListBasics<E> on List<E> {
   /// var sorted = list.sortedCopyBy((e) => e.toString().length);
   /// // list is still [-12, 3, 10]. sorted is [3, 10, -12].
   /// ```
-  List<E> sortedCopyBy(Comparable<Object?> Function(E) sortKey) {
+  List<E> sortedCopyBy(Comparable<dynamic> Function(E) sortKey) {
     return List<E>.of(this)..sortBy(sortKey);
   }
 

--- a/lib/src/sort_key_compare.dart
+++ b/lib/src/sort_key_compare.dart
@@ -13,7 +13,11 @@
 /// It is expected that all calls to this function within a single ordering
 /// or sorting will provide the same cache instance with each call.
 int sortKeyCompare<T>(
-    T a, T b, Comparable Function(T) sortKey, Map<T, Comparable> sortKeyCache) {
+  T a,
+  T b,
+  Comparable<Object?> Function(T) sortKey,
+  Map<T, Comparable<Object?>> sortKeyCache,
+) {
   final keyA = sortKeyCache.putIfAbsent(a, () => sortKey(a));
   final keyB = sortKeyCache.putIfAbsent(b, () => sortKey(b));
   return keyA.compareTo(keyB);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 name: basics
-version: 0.9.0
+version: 0.8.1
 description: A Dart library containing convenient extension methods on basic Dart objects.
 repository: https://github.com/google/dart-basics
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,12 @@
 # license that can be found in the LICENSE file.
 
 name: basics
-version: 0.8.0
+version: 0.9.0
 description: A Dart library containing convenient extension methods on basic Dart objects.
 repository: https://github.com/google/dart-basics
 
 environment:
-  sdk: ">=2.15.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -467,8 +467,8 @@ void main() {
       expect(values.getRange(2, 4), [12, 4]);
       expect(values.getRange(0, 2), [3, 8]);
       expect(values.getRange(3, 5), [4, 1]);
-      expect(values.getRange(3, 3), []);
-      expect(values.getRange(5, 5), []);
+      expect(values.getRange(3, 3), <int>[]);
+      expect(values.getRange(5, 5), <int>[]);
     });
 
     test('matches the behavior of List#getRange', () {
@@ -515,7 +515,7 @@ num _getItemSize(dynamic item) {
   throw UnimplementedError();
 }
 
-RangeError _getRangeError(Iterable Function() f) {
+RangeError _getRangeError(Iterable<Object?> Function() f) {
   try {
     f();
   } on RangeError catch (e) {

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('returns true for an empty iterable', () {
-      final empty = [];
+      final empty = <Object>[];
       final result = empty.none((e) => e.toString() == 'foo');
       expect(result, isTrue);
     });
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('returns false for an empty iterable', () {
-      final empty = [];
+      final empty = <Object>[];
       final result = empty.one((e) => e.toString() == 'foo');
       expect(result, isFalse);
     });
@@ -94,8 +94,8 @@ void main() {
     });
 
     test('returns false for two empty iterables', () {
-      final empty1 = [];
-      final empty2 = [];
+      final empty1 = <Object>[];
+      final empty2 = <Object>[];
 
       expect(empty1.containsAny(empty2), isFalse);
       expect(empty2.containsAny(empty1), isFalse);
@@ -147,8 +147,8 @@ void main() {
     });
 
     test('returns true for two empty iterables', () {
-      final empty1 = [];
-      final empty2 = [];
+      final empty1 = <Object>[];
+      final empty2 = <Object>[];
 
       expect(empty1.containsAll(empty2), isTrue);
     });
@@ -422,7 +422,7 @@ void main() {
       expect(<double>[].sum(), 0);
       expect(<num>[].sum((n) => n * 2), 0);
       expect(<String>[].sum((s) => s.length), 0);
-      expect([].sum((n) => n * 2), 0);
+      expect(<int>[].sum((n) => n * 2), 0);
     });
 
     test('returns sum of custom addend', () {
@@ -449,7 +449,7 @@ void main() {
 
   group('getRandom', () {
     test('returns null for an empty iterable', () {
-      expect([].getRandom(), isNull);
+      expect(<int>[].getRandom(), isNull);
     });
 
     test('returns the only value of an iterable of length 1', () {

--- a/test/list_basics_test.dart
+++ b/test/list_basics_test.dart
@@ -59,7 +59,7 @@ void main() {
         'starts from the final element if start is greater than the length '
         'of the list', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 100, end: 1), []);
+      expect(list.slice(start: 100, end: 1), <int>[]);
       expect(list.slice(start: 100, end: 1, step: -1), [4, 3]);
     });
 
@@ -81,65 +81,65 @@ void main() {
         'ends with the first element if end is less than the negative length '
         'of the list', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 2, end: -100), []);
+      expect(list.slice(start: 2, end: -100), <int>[]);
       expect(list.slice(start: 2, end: -100, step: -1), [3, 2, 1]);
     });
 
     test('returns an empty list if start and end are equal', () {
       final list = [1, 2, 3, 4, 5];
-      expect(list.slice(start: 2, end: 2), []);
-      expect(list.slice(start: -2, end: -2), []);
+      expect(list.slice(start: 2, end: 2), <int>[]);
+      expect(list.slice(start: -2, end: -2), <int>[]);
     });
 
     test(
         'returns an empty list if start and end are not equal but correspond '
         'to the same element', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 1, end: -3), []);
-      expect(list.slice(start: 2, end: -2), []);
+      expect(list.slice(start: 1, end: -3), <int>[]);
+      expect(list.slice(start: 2, end: -2), <int>[]);
     });
 
     test(
         'returns an empty list if start (or its equivalent index) is greater '
         'than end (or its equivalent index) and step is positive', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 3, end: 1), []);
-      expect(list.slice(start: -1, end: 1), []);
-      expect(list.slice(start: 3, end: -3), []);
-      expect(list.slice(start: -1, end: -3), []);
-      expect(list.slice(start: 3, end: -100), []);
+      expect(list.slice(start: 3, end: 1), <int>[]);
+      expect(list.slice(start: -1, end: 1), <int>[]);
+      expect(list.slice(start: 3, end: -3), <int>[]);
+      expect(list.slice(start: -1, end: -3), <int>[]);
+      expect(list.slice(start: 3, end: -100), <int>[]);
     });
 
     test(
         'returns an empty list if start (or its equivalent index) is less than '
         'end (or its equivalent index) and step is negative', () {
       final list = [1, 2, 3, 4];
-      expect(list.slice(start: 1, end: 3, step: -1), []);
-      expect(list.slice(start: -3, end: 3, step: -1), []);
-      expect(list.slice(start: 1, end: -1, step: -1), []);
-      expect(list.slice(start: -3, end: -1, step: -1), []);
-      expect(list.slice(start: 1, end: 100, step: -1), []);
+      expect(list.slice(start: 1, end: 3, step: -1), <int>[]);
+      expect(list.slice(start: -3, end: 3, step: -1), <int>[]);
+      expect(list.slice(start: 1, end: -1, step: -1), <int>[]);
+      expect(list.slice(start: -3, end: -1, step: -1), <int>[]);
+      expect(list.slice(start: 1, end: 100, step: -1), <int>[]);
     });
 
     test('behaves predictably when the bounds are increased in any direction',
         () {
       final list = [1, 2, 3, 4];
 
-      expect(list.slice(start: 0, end: 0), []);
+      expect(list.slice(start: 0, end: 0), <int>[]);
       expect(list.slice(start: 0, end: 1), [1]);
       expect(list.slice(start: 0, end: 2), [1, 2]);
       expect(list.slice(start: 0, end: 3), [1, 2, 3]);
       expect(list.slice(start: 0, end: 4), [1, 2, 3, 4]);
       expect(list.slice(start: 0, end: 5), [1, 2, 3, 4]);
 
-      expect(list.slice(start: 0, end: -5), []);
-      expect(list.slice(start: 0, end: -4), []);
+      expect(list.slice(start: 0, end: -5), <int>[]);
+      expect(list.slice(start: 0, end: -4), <int>[]);
       expect(list.slice(start: 0, end: -3), [1]);
       expect(list.slice(start: 0, end: -2), [1, 2]);
       expect(list.slice(start: 0, end: -1), [1, 2, 3]);
 
-      expect(list.slice(start: 5, end: 4), []);
-      expect(list.slice(start: 4, end: 4), []);
+      expect(list.slice(start: 5, end: 4), <int>[]);
+      expect(list.slice(start: 4, end: 4), <int>[]);
       expect(list.slice(start: 3, end: 4), [4]);
       expect(list.slice(start: 2, end: 4), [3, 4]);
       expect(list.slice(start: 1, end: 4), [2, 3, 4]);
@@ -150,18 +150,18 @@ void main() {
       expect(list.slice(start: -4, end: 4), [1, 2, 3, 4]);
       expect(list.slice(start: -5, end: 4), [1, 2, 3, 4]);
 
-      expect(list.slice(start: 3, end: 3, step: -1), []);
+      expect(list.slice(start: 3, end: 3, step: -1), <int>[]);
       expect(list.slice(start: 3, end: 2, step: -1), [4]);
       expect(list.slice(start: 3, end: 1, step: -1), [4, 3]);
       expect(list.slice(start: 3, end: 0, step: -1), [4, 3, 2]);
 
-      expect(list.slice(start: 3, end: -1, step: -1), []);
+      expect(list.slice(start: 3, end: -1, step: -1), <int>[]);
       expect(list.slice(start: 3, end: -2, step: -1), [4]);
       expect(list.slice(start: 3, end: -3, step: -1), [4, 3]);
       expect(list.slice(start: 3, end: -4, step: -1), [4, 3, 2]);
       expect(list.slice(start: 3, end: -5, step: -1), [4, 3, 2, 1]);
 
-      expect(list.slice(start: 0, end: 0, step: -1), []);
+      expect(list.slice(start: 0, end: 0, step: -1), <int>[]);
       expect(list.slice(start: 1, end: 0, step: -1), [2]);
       expect(list.slice(start: 2, end: 0, step: -1), [3, 2]);
       expect(list.slice(start: 3, end: 0, step: -1), [4, 3, 2]);
@@ -171,13 +171,13 @@ void main() {
       expect(list.slice(start: -1, end: 0, step: -1), [4, 3, 2]);
       expect(list.slice(start: -2, end: 0, step: -1), [3, 2]);
       expect(list.slice(start: -3, end: 0, step: -1), [2]);
-      expect(list.slice(start: -4, end: 0, step: -1), []);
+      expect(list.slice(start: -4, end: 0, step: -1), <int>[]);
 
       expect(list.slice(start: -1, end: -5, step: -1), [4, 3, 2, 1]);
       expect(list.slice(start: -2, end: -5, step: -1), [3, 2, 1]);
       expect(list.slice(start: -3, end: -5, step: -1), [2, 1]);
       expect(list.slice(start: -4, end: -5, step: -1), [1]);
-      expect(list.slice(start: -5, end: -5, step: -1), []);
+      expect(list.slice(start: -5, end: -5, step: -1), <int>[]);
     });
   });
 
@@ -248,7 +248,7 @@ void main() {
 
   group('takeRandom', () {
     test('returns null for an empty list', () {
-      expect([].takeRandom(), isNull);
+      expect(<Object>[].takeRandom(), isNull);
     });
 
     test('removes the only element of a list of length 1', () {

--- a/test/map_basics_test.dart
+++ b/test/map_basics_test.dart
@@ -60,8 +60,8 @@ void main() {
     });
 
     test('returns an empty map when called on an empty map', () {
-      final map = {};
-      expect(map.invert(), {});
+      final map = <Object, Object>{};
+      expect(map.invert(), <Object, Object>{});
     });
   });
 }


### PR DESCRIPTION
Enable the `strict-casts`, `strict-inference`, and `strict-raw-types`
options for the analyzer.  Fix missing types accordingly.

Also remove an obsolete analyzer option.