### PR TITLE
Add `ComparableBasics` to provide comparison operators to `Comparable` objects

### DIFF
--- a/lib/comparable_basics.dart
+++ b/lib/comparable_basics.dart
@@ -1,0 +1,24 @@
+// Copyright (c) 2022, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/// Utility extension methods for the [Comparable] class.
+extension ComparableBasics<T> on Comparable<T> {
+  /// Returns true if [this] should be ordered strictly before [other].
+  bool operator <(T other) => compareTo(other) < 0;
+
+  /// Returns true if [this] should be ordered strictly after [other].
+  bool operator >(T other) => compareTo(other) > 0;
+
+  /// Returns true if [this] should be ordered before or with [other].
+  bool operator <=(T other) => compareTo(other) <= 0;
+
+  /// Returns true if [this] should be ordered after or with [other].
+  bool operator >=(T other) => compareTo(other) >= 0;
+}
+
+/// Returns the greater of two [Comparable] objects.
+T max<T extends Comparable<Object>>(T a, T b) => (a >= b) ? a : b;
+
+/// Returns the lesser of two [Comparable] objects.
+T min<T extends Comparable<Object>>(T a, T b) => (a <= b) ? a : b;

--- a/lib/comparable_basics.dart
+++ b/lib/comparable_basics.dart
@@ -2,6 +2,8 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+import 'dart:math' as math show min, max;
+
 /// Utility extension methods for the [Comparable] class.
 extension ComparableBasics<T> on Comparable<T> {
   /// Returns true if [this] should be ordered strictly before [other].
@@ -18,7 +20,21 @@ extension ComparableBasics<T> on Comparable<T> {
 }
 
 /// Returns the greater of two [Comparable] objects.
-T max<T extends Comparable<Object>>(T a, T b) => (a >= b) ? a : b;
+///
+/// For [num] values, behaves identically to [math.max].
+T max<T extends Comparable<Object>>(T a, T b) {
+  if (a is num) {
+    return math.max(a, b as num) as T;
+  }
+  return (a >= b) ? a : b;
+}
 
 /// Returns the lesser of two [Comparable] objects.
-T min<T extends Comparable<Object>>(T a, T b) => (a <= b) ? a : b;
+///
+/// For [num] values, behaves identically to [math.min].
+T min<T extends Comparable<Object>>(T a, T b) {
+  if (a is num) {
+    return math.min(a, b as num) as T;
+  }
+  return (a <= b) ? a : b;
+}

--- a/lib/comparable_basics.dart
+++ b/lib/comparable_basics.dart
@@ -22,6 +22,9 @@ extension ComparableBasics<T> on Comparable<T> {
 /// Returns the greater of two [Comparable] objects.
 ///
 /// For [num] values, behaves identically to [math.max].
+///
+/// If the arguments compare equal, then it is unspecified which of the two
+/// arguments is returned.
 T max<T extends Comparable<Object>>(T a, T b) {
   if (a is num) {
     return math.max(a, b as num) as T;
@@ -32,6 +35,9 @@ T max<T extends Comparable<Object>>(T a, T b) {
 /// Returns the lesser of two [Comparable] objects.
 ///
 /// For [num] values, behaves identically to [math.min].
+///
+/// If the arguments compare equal, then it is unspecified which of the two
+/// arguments is returned.
 T min<T extends Comparable<Object>>(T a, T b) {
   if (a is num) {
     return math.min(a, b as num) as T;

--- a/test/comparable_basics_test.dart
+++ b/test/comparable_basics_test.dart
@@ -1,0 +1,72 @@
+// Copyright (c) 2022, Google Inc. Please see the AUTHORS file for details.
+// All rights reserved. Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+import 'package:basics/comparable_basics.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Comparable', () {
+    var date1 = _Wrapped(DateTime.now());
+    var date2 = _Wrapped(date1.value.add(const Duration(seconds: 1)));
+    var s1 = _Wrapped('aardvark');
+    var s2 = _Wrapped('zebra');
+
+    test('ComparisonOperators extension', () {
+      expect('aardvark' < 'zebra', true);
+
+      expect(date1 < date2, true);
+
+      expect(s1 < s2, true);
+      expect(s2 < s1, false);
+      expect(s1 > s2, false);
+      expect(s2 > s1, true);
+
+      expect(s1 <= s2, true);
+      expect(s2 <= s1, false);
+      expect(s1 >= s2, false);
+      expect(s2 >= s1, true);
+
+      expect(s1 <= s1, true);
+      expect(s1 >= s1, true);
+    });
+
+    test('min/max', () {
+      expect(max(date1, date2), date2);
+      expect(max(date2, date1), date2);
+
+      expect(min(date1, date2), date1);
+      expect(min(date2, date1), date1);
+
+      // [int] and [double] (and combinations of them) can be potentially tricky
+      // because their inheritance tree requires both of them to implement
+      // `Comparable<num>` instead of `Comparable<int>` and `Comparable<double>`
+      // respectively.
+      var i = 3;
+      var d = 3.1415;
+      expect(max(i, d), d);
+      expect(max(d, i), d);
+      expect(min(i, d), i);
+      expect(min(d, i), i);
+
+      expect(max(i, i), i);
+      expect(min(i, i), i);
+      expect(max(d, d), d);
+      expect(min(d, d), d);
+    });
+  });
+}
+
+/// A wrapper class that provides a [Comparable.compareTo] implementation and
+/// that explicitly does not provide its own comparison operators.
+///
+/// Used to test the [ComparisonOperators] extension.  We intentionally avoid
+/// using `T` directly in case it has its own comparison operators.
+class _Wrapped<T extends Comparable<Object>> implements Comparable<_Wrapped<T>> {
+  _Wrapped(this.value);
+
+  final T value;
+
+  @override
+  int compareTo(_Wrapped<T> other) => value.compareTo(other.value);
+}

--- a/test/comparable_basics_test.dart
+++ b/test/comparable_basics_test.dart
@@ -2,71 +2,124 @@
 // All rights reserved. Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:basics/comparable_basics.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('Comparable', () {
-    var date1 = _Wrapped(DateTime.now());
-    var date2 = _Wrapped(date1.value.add(const Duration(seconds: 1)));
-    var s1 = _Wrapped('aardvark');
-    var s2 = _Wrapped('zebra');
+  var date1 = _HideComparisonOperators(DateTime.now());
+  var date2 =
+      _HideComparisonOperators(date1.value.add(const Duration(seconds: 1)));
+  var s1 = _HideComparisonOperators('aardvark');
+  var s2 = _HideComparisonOperators('zebra');
 
-    test('ComparisonOperators extension', () {
-      expect('aardvark' < 'zebra', true);
+  test('comparison operators work', () {
+    expect('aardvark' < 'zebra', true);
 
-      expect(date1 < date2, true);
+    expect(date1 < date2, true);
 
-      expect(s1 < s2, true);
-      expect(s2 < s1, false);
-      expect(s1 > s2, false);
-      expect(s2 > s1, true);
+    expect(s1 < s2, true);
+    expect(s2 < s1, false);
+    expect(s1 > s2, false);
+    expect(s2 > s1, true);
 
-      expect(s1 <= s2, true);
-      expect(s2 <= s1, false);
-      expect(s1 >= s2, false);
-      expect(s2 >= s1, true);
+    expect(s1 <= s2, true);
+    expect(s2 <= s1, false);
+    expect(s1 >= s2, false);
+    expect(s2 >= s1, true);
 
-      expect(s1 <= s1, true);
-      expect(s1 >= s1, true);
-    });
+    expect(s1 <= s1, true);
+    expect(s1 >= s1, true);
+  });
 
-    test('min/max', () {
-      expect(max(date1, date2), date2);
-      expect(max(date2, date1), date2);
+  test('min/max work', () {
+    expect(max(date1, date2), date2);
+    expect(max(date2, date1), date2);
 
-      expect(min(date1, date2), date1);
-      expect(min(date2, date1), date1);
+    expect(min(date1, date2), date1);
+    expect(min(date2, date1), date1);
 
-      // [int] and [double] (and combinations of them) can be potentially tricky
-      // because their inheritance tree requires both of them to implement
-      // `Comparable<num>` instead of `Comparable<int>` and `Comparable<double>`
-      // respectively.
-      var i = 3;
-      var d = 3.1415;
-      expect(max(i, d), d);
-      expect(max(d, i), d);
-      expect(min(i, d), i);
-      expect(min(d, i), i);
+    // [int] and [double] (and combinations of them) can be potentially tricky
+    // because their inheritance tree requires both of them to implement
+    // `Comparable<num>` instead of `Comparable<int>` and `Comparable<double>`
+    // respectively.
+    var i = 3;
+    var d = 3.1415;
+    expect(max(i, d), d);
+    expect(max(d, i), d);
+    expect(min(i, d), i);
+    expect(min(d, i), i);
 
-      expect(max(i, i), i);
-      expect(min(i, i), i);
-      expect(max(d, d), d);
-      expect(min(d, d), d);
-    });
+    expect(max(i, i), i);
+    expect(min(i, i), i);
+    expect(max(d, d), d);
+    expect(min(d, d), d);
+  });
+
+  test("min/max behave like dart:math's min/max", () {
+    expect(min(-0.0, 0.0), math.min(-0.0, 0.0));
+    expect(min(0.0, -0.0), math.min(0.0, -0.0));
+    expect(max(-0.0, 0.0), math.max(-0.0, 0.0));
+    expect(max(0.0, -0.0), math.max(0.0, -0.0));
+
+    expect(
+      min(double.nan, 0.0),
+      _matchesDouble(math.min(double.nan, 0.0)),
+    );
+    expect(
+      min(0.0, double.nan),
+      _matchesDouble(math.min(0.0, double.nan)),
+    );
+    expect(
+      min(double.nan, double.nan),
+      _matchesDouble(math.min(double.nan, double.nan)),
+    );
+    expect(
+      max(double.nan, 0.0),
+      _matchesDouble(math.max(double.nan, 0.0)),
+    );
+    expect(
+      max(0.0, double.nan),
+      _matchesDouble(math.max(0.0, double.nan)),
+    );
+    expect(
+      max(double.nan, double.nan),
+      _matchesDouble(math.max(double.nan, double.nan)),
+    );
+  });
+
+  test('_matchesDouble works', () {
+    expect(_matchesDouble(0.5).matches(0.5, {}), true);
+    expect(_matchesDouble(0.5).matches(0.0, {}), false);
+    expect(_matchesDouble(double.nan).matches(double.nan, {}), true);
+    expect(_matchesDouble(0.0).matches(double.nan, {}), false);
+    expect(_matchesDouble(double.nan).matches(0.0, {}), false);
   });
 }
 
-/// A wrapper class that provides a [Comparable.compareTo] implementation and
+/// A wrapper class that provides a [Comparable.compareTo] implementation but
 /// that explicitly does not provide its own comparison operators.
 ///
-/// Used to test the [ComparisonOperators] extension.  We intentionally avoid
+/// Used to test the [ComparableBasics] extension.  We intentionally avoid
 /// using `T` directly in case it has its own comparison operators.
-class _Wrapped<T extends Comparable<Object>> implements Comparable<_Wrapped<T>> {
-  _Wrapped(this.value);
+class _HideComparisonOperators<T extends Comparable<Object>>
+    implements Comparable<_HideComparisonOperators<T>> {
+  _HideComparisonOperators(this.value);
 
   final T value;
 
   @override
-  int compareTo(_Wrapped<T> other) => value.compareTo(other.value);
+  int compareTo(_HideComparisonOperators<T> other) =>
+      value.compareTo(other.value);
+}
+
+/// Returns a [Matcher] for [double] equality that, unlike [equals]. considers
+/// NaN values to be equal to other NaN values.
+Matcher _matchesDouble(double expectedValue) {
+  bool matchesDoubleInternal(double actualValue) =>
+      (expectedValue == actualValue) ||
+      (expectedValue.isNaN && actualValue.isNaN);
+
+  return predicate(matchesDoubleInternal, '<$expectedValue>');
 }


### PR DESCRIPTION
Add a `ComparableBasics` extension to provide comparison operators
(`<`, `>`, etc.) to `Comparable` objects.  Also add `min`/`max`
functions that, unlike `min`/`max` from `dart:math`, work on any
`Comparable` arguments and not just `num`s.

Note that `DateTime`'s own comparison operators are no longer
necessary, but I'm leaving them alone because:
* They deserve more detailed documentation.
* Existing users might want those without necessarily enabling
  comparison operators for all other `Comparable` types.