### PR TITLE
Version bump 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.8.0]
+
+* Added `ComparableBasics`.
+* Added `getRange` to `Iterable`.
+* Added `isNullOrBlank` and `isNotNullOrBlank` to `String?`
+* Improved performance of `maxBy`, `minBy` and `sortBy` by adding a cache.
+
 ## [0.7.0]
 
 Added `copyWith`, `addCalendarDays`, and `calendarDaysTill` to `DateTimeBasics`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 name: basics
-version: 0.7.0+1
+version: 0.8.0
 description: A Dart library containing convenient extension methods on basic Dart objects.
 repository: https://github.com/google/dart-basics
 


### PR DESCRIPTION
Bumping version to `0.8.0`, doing middle number increase because of new API.

Includes: https://github.com/google/dart-basics/pull/37 https://github.com/google/dart-basics/pull/39 https://github.com/google/dart-basics/pull/40 https://github.com/google/dart-basics/pull/41 https://github.com/google/dart-basics/pull/43

Thanks @jamesderlin, @devoncarew, and @zdg2102 for the contributions!