### PR TITLE
Switch to using the 'setup-dart' action for the CI

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,9 @@
+# Dependabot configuration file.
+version: 2
+enable-beta-ecosystems: true
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,17 +1,30 @@
 name: Dart CI
 
-on: [push, pull_request]
+on:
+  schedule:
+    # “At 00:00 (UTC) on Sunday.”
+    - cron: '0 0 * * 0'
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      image: google/dart:latest
+
     steps:
-    - uses: actions/checkout@v2
-    - name: Install dependencies
-      run: dart pub get
-    - name: Analyze code
-      run: dart analyze
-    - name: Run tests
-      run: dart test
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
+
+      - name: Install dependencies
+        run: dart pub get
+  
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze project source
+        run: dart analyze --fatal-infos
+
+      - name: Run tests
+        run: dart test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Dart Basics
+[![Dart CI](https://github.com/google/dart-basics/actions/workflows/dart.yml/badge.svg)](https://github.com/google/dart-basics/actions/workflows/dart.yml)
+[![pub package](https://img.shields.io/pub/v/basics.svg)](https://pub.dev/packages/basics)
+[![package publisher](https://img.shields.io/pub/publisher/basics.svg)](https://pub.dev/packages/basics/publisher)
 
 This repository contains a collection of useful extension methods on the
 built-in objects in Dart, such as String, Iterable, and Object.


### PR DESCRIPTION
- switch to using the 'setup-dart' action for the CI
- enable dependabot - this will send PRs to update the github actions versions as necessary
- add some markdown badges to the readme
