### PR TITLE
Average Extension Methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ doc/api/
 
 # macOS stuff.
 .DS_Store
+
+.vscode/launch.json

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -256,7 +256,7 @@ extension NumIterableBasics<E extends num> on Iterable<E> {
   /// Returns the average of all the values in this iterable.
   ///
   /// If [addend] is provided, it will be used to compute the value to be
-  /// summed.
+  /// averaged.
   ///
   /// Returns 0 if [this] is empty.
   ///

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -154,6 +154,22 @@ extension IterableBasics<E> on Iterable<E> {
       ? 0
       : this.fold(0, (prev, element) => prev + addend(element));
 
+  /// Returns the average of all the values in this iterable, as defined by
+  /// [addend].
+  ///
+  /// Returns 0 if [this] is empty.
+  ///
+  /// Example:
+  /// ```dart
+  /// ['a', 'aa', 'aaa'].average((s) => s.length); // 2
+  /// ```
+  num average(num Function(E) addend) {
+    if (this.isEmpty) return 0;
+
+    return this.fold(0, (prev, element) => (prev as num) + addend(element)) /
+        this.length;
+  }
+
   /// Returns a random element of [this], or [null] if [this] is empty.
   ///
   /// If [seed] is provided, will be used as the random seed for determining
@@ -236,6 +252,32 @@ extension NumIterableBasics<E extends num> on Iterable<E> {
     return addend == null
         ? this.reduce((a, b) => (a + b) as E)
         : this.fold(0, (prev, element) => prev + addend(element));
+  }
+
+  /// Returns the average of all the values in this iterable.
+  ///
+  /// If [addend] is provided, it will be used to compute the value to be
+  /// summed.
+  ///
+  /// Returns 0 if [this] is empty.
+  ///
+  /// Example:
+  /// ```dart
+  /// [2, 2, 4, 8].average(); // 4.
+  /// [2, 2, 4, 8].average((i) => i + 1); // 5.
+  /// [].average() // 0.
+  /// ```
+  num average([num Function(E)? addend]) {
+    if (this.isEmpty) return 0;
+
+    return addend == null
+        ? this.reduce((a, b) => (a + b) as E) / this.length
+        : this.fold(
+              0,
+              (prev, element) =>
+                  (prev == null ? 0 : prev as E) + addend(element),
+            ) /
+            this.length;
   }
 }
 

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -157,14 +157,15 @@ extension IterableBasics<E> on Iterable<E> {
   /// Returns the average of all the values in this iterable, as defined by
   /// [addend].
   ///
-  /// Returns 0 if [this] is empty.
+  /// Returns null if [this] is empty.
   ///
   /// Example:
   /// ```dart
   /// ['a', 'aa', 'aaa'].average((s) => s.length); // 2
+  /// [].average(); // null
   /// ```
-  num average(num Function(E) addend) {
-    if (this.isEmpty) return 0;
+  num? average(num Function(E) addend) {
+    if (this.isEmpty) return null;
 
     return this.sum(addend) / this.length;
   }
@@ -258,16 +259,16 @@ extension NumIterableBasics<E extends num> on Iterable<E> {
   /// If [addend] is provided, it will be used to compute the value to be
   /// averaged.
   ///
-  /// Returns 0 if [this] is empty.
+  /// Returns null if [this] is empty.
   ///
   /// Example:
   /// ```dart
   /// [2, 2, 4, 8].average(); // 4.
   /// [2, 2, 4, 8].average((i) => i + 1); // 5.
-  /// [].average() // 0.
+  /// [].average() // null.
   /// ```
-  num average([num Function(E)? addend]) {
-    if (this.isEmpty) return 0;
+  num? average([num Function(E)? addend]) {
+    if (this.isEmpty) return null;
 
     return this.sum(addend) / this.length;
   }

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -256,7 +256,7 @@ extension NumIterableBasics<E extends num> on Iterable<E> {
 
   /// Returns the average of all the values in this iterable.
   ///
-  /// If [addend] is provided, it will be used to compute the value to be
+  /// If [value] is provided, it will be used to compute the value to be
   /// averaged.
   ///
   /// Returns null if [this] is empty.
@@ -267,10 +267,10 @@ extension NumIterableBasics<E extends num> on Iterable<E> {
   /// [2, 2, 4, 8].average((i) => i + 1); // 5.
   /// [].average() // null.
   /// ```
-  num? average([num Function(E)? addend]) {
+  num? average([num Function(E)? value]) {
     if (this.isEmpty) return null;
 
-    return this.sum(addend) / this.length;
+    return this.sum(value) / this.length;
   }
 }
 

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -166,8 +166,7 @@ extension IterableBasics<E> on Iterable<E> {
   num average(num Function(E) addend) {
     if (this.isEmpty) return 0;
 
-    return this.fold(0, (prev, element) => (prev as num) + addend(element)) /
-        this.length;
+    return this.sum(addend) / this.length;
   }
 
   /// Returns a random element of [this], or [null] if [this] is empty.
@@ -270,14 +269,7 @@ extension NumIterableBasics<E extends num> on Iterable<E> {
   num average([num Function(E)? addend]) {
     if (this.isEmpty) return 0;
 
-    return addend == null
-        ? this.reduce((a, b) => (a + b) as E) / this.length
-        : this.fold(
-              0,
-              (prev, element) =>
-                  (prev == null ? 0 : prev as E) + addend(element),
-            ) /
-            this.length;
+    return this.sum(addend) / this.length;
   }
 }
 

--- a/lib/iterable_basics.dart
+++ b/lib/iterable_basics.dart
@@ -155,7 +155,7 @@ extension IterableBasics<E> on Iterable<E> {
       : this.fold(0, (prev, element) => prev + addend(element));
 
   /// Returns the average of all the values in this iterable, as defined by
-  /// [addend].
+  /// [value].
   ///
   /// Returns null if [this] is empty.
   ///
@@ -164,10 +164,10 @@ extension IterableBasics<E> on Iterable<E> {
   /// ['a', 'aa', 'aaa'].average((s) => s.length); // 2
   /// [].average(); // null
   /// ```
-  num? average(num Function(E) addend) {
+  num? average(num Function(E) value) {
     if (this.isEmpty) return null;
 
-    return this.sum(addend) / this.length;
+    return this.sum(value) / this.length;
   }
 
   /// Returns a random element of [this], or [null] if [this] is empty.

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -409,13 +409,15 @@ void main() {
 
   group('average', () {
     test('returns average on list of numbers', () {
-      final nums = [2, 2, 4, 8];
-      final ints = [2, 2, 2];
+      final nums = <int>[2, 2, 4, 8];
+      final ints = <int>[2, 2, 2];
+      final numbers = [1.5, 1.5, 3, 3];
 
       expect(nums.average(), 4);
       expect(ints.average(), 2);
       expect(ints.average((n) => n * 2), 4);
       expect(nums.average((n) => n + 1), 5);
+      expect(numbers.average(), 2.25);
     });
 
     test('returns 0 on empty lists', () {

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -420,7 +420,7 @@ void main() {
       expect(numbers.average(), 2.25);
     });
 
-    test('returns 0 on empty lists', () {
+    test('returns null on empty lists', () {
       expect(<int>[].average(), null);
       expect(<double>[].average(), null);
       expect(<num>[].average((n) => n * 2), null);

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -412,8 +412,6 @@ void main() {
       final nums = [2, 2, 4, 8];
       final ints = [2, 2, 2];
 
-      nums.average();
-
       expect(nums.average(), 4);
       expect(ints.average(), 2);
       expect(ints.average((n) => n * 2), 4);

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -407,6 +407,49 @@ void main() {
     });
   });
 
+  group('average', () {
+    test('returns average on list of numbers', () {
+      final nums = [2, 2, 4, 8];
+      final ints = [2, 2, 2];
+
+      nums.average();
+
+      expect(nums.average(), 4);
+      expect(ints.average(), 2);
+      expect(ints.average((n) => n * 2), 4);
+      expect(nums.average((n) => n + 1), 5);
+    });
+
+    test('returns 0 on empty lists', () {
+      expect(<int>[].average(), 0);
+      expect(<double>[].average(), 0);
+      expect(<num>[].average((n) => n * 2), 0);
+      expect(<String>[].average((s) => s.length), 0);
+      expect(<int>[].average((n) => n * 2), 0);
+    });
+
+    test('returns average of custom addend', () {
+      final strings = ['a', 'aa', 'aaa'];
+
+      expect(strings.average((s) => s.length), 2);
+    });
+
+    test('works on sets', () {
+      final strings = {'a', 'aa', 'aaa'};
+
+      expect(strings.average((s) => s.length), 2);
+    });
+
+    test('works on dynamic list with custom addend', () {
+      final items = [1, 'aaa', 2.0];
+
+      expect(items.average((a) => _getItemSize(a)), equals(2));
+
+      items.add(0.5);
+      expect(items.average((a) => _getItemSize(a)), equals(1.625));
+    });
+  });
+
   group('sum', () {
     test('returns sum on list of numbers', () {
       final nums = [1.5, 2, 3];

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -428,7 +428,7 @@ void main() {
       expect(<int>[].average((n) => n * 2), null);
     });
 
-    test('returns average of custom addend', () {
+    test('returns average of custom value function', () {
       final strings = ['a', 'aa', 'aaa'];
 
       expect(strings.average((s) => s.length), 2);
@@ -440,7 +440,7 @@ void main() {
       expect(strings.average((s) => s.length), 2);
     });
 
-    test('works on dynamic list with custom addend', () {
+    test('works on dynamic list with custom value function', () {
       final items = [1, 'aaa', 2.0];
 
       expect(items.average((a) => _getItemSize(a)), equals(2));

--- a/test/iterable_basics_test.dart
+++ b/test/iterable_basics_test.dart
@@ -421,11 +421,11 @@ void main() {
     });
 
     test('returns 0 on empty lists', () {
-      expect(<int>[].average(), 0);
-      expect(<double>[].average(), 0);
-      expect(<num>[].average((n) => n * 2), 0);
-      expect(<String>[].average((s) => s.length), 0);
-      expect(<int>[].average((n) => n * 2), 0);
+      expect(<int>[].average(), null);
+      expect(<double>[].average(), null);
+      expect(<num>[].average((n) => n * 2), null);
+      expect(<String>[].average((s) => s.length), null);
+      expect(<int>[].average((n) => n * 2), null);
     });
 
     test('returns average of custom addend', () {


### PR DESCRIPTION
I noticed there are no basic `average` extension methods in the code, so I added for `IterableBasics` and `NumIterableBasics`. Let me know if miss or mess something.