### PR TITLE
Pluck Method for Sets That Have Maps Children

### DIFF
--- a/lib/set_basics.dart
+++ b/lib/set_basics.dart
@@ -121,3 +121,9 @@ extension SetBasics<E> on Set<E> {
     return groups;
   }
 }
+
+extension MapSets<E extends Map<String, dynamic>> on Set<E> {
+  List<dynamic> pluck(String key) {
+    return this.map((item) => item[key]).where((item) => item != null).toList();
+  }
+}

--- a/lib/set_basics.dart
+++ b/lib/set_basics.dart
@@ -122,8 +122,29 @@ extension SetBasics<E> on Set<E> {
   }
 }
 
-extension MapSets<E extends Map<String, dynamic>> on Set<E> {
-  List<dynamic> pluck(String key) {
-    return this.map((item) => item[key]).where((item) => item != null).toList();
-  }
+/// Utility extension methods for the native [Set] class with Map children.
+extension MapSetsBasics<E extends Map<String, dynamic>> on Set<E> {
+  /// Plucks a list of values from maps using a key.
+  ///
+  /// Example:
+  /// ```dart
+  /// final products = {
+  ///   {
+  ///     'sku': 'FOO-1',
+  ///     'title: 'Backpack',
+  ///     'price': 9.99,
+  ///   },
+  ///   {
+  ///     'sku': 'FOO-2',
+  ///     'title': 'Wallet',
+  ///     'price': 8.99
+  ///   }
+  /// };
+  ///
+  /// final titles = products.pluck('title'); // ['Backpack', 'Wallet']
+  /// ```
+  ///
+  /// The [key] is the target key to be plucked from each map.
+  List<dynamic> pluck(String key) =>
+      this.map((item) => item[key]).where((item) => item != null).toList();
 }

--- a/test/set_basics_test.dart
+++ b/test/set_basics_test.dart
@@ -257,4 +257,72 @@ void main() {
       expect(values.classify<int>((e) => e.length), <int, Set<String>>{});
     });
   });
+
+  group('pluck', () {
+    test('Pluck values by key', () {
+      final items = {
+        {
+          'sku': 'SKU-123',
+          'title': 'Soap',
+          'price': 2.23
+        },
+        {
+          'sku': 'SKU-124',
+          'title': 'Shampoo',
+          'price': 2.25
+        }
+      };
+
+      final values = items.pluck('price');
+
+      expect(values, [2.23, 2.25]);
+    });
+
+    test('Results to empty list when plucking values by key that does not exist.', () {
+      final items = {
+        {
+          'first_name': 'John',
+          'last_name': 'Doe',
+          'age': 23
+        },
+        {
+          'first_name': 'Jane',
+          'last_name': 'Doe',
+          'age': 25
+        },
+      };
+
+      final values = items.pluck('address');
+
+      expect(values.isEmpty, true);
+    });
+
+    test('Pluck mixed values by key', () {
+      final items = {
+        {
+          'id': 123,
+          'title': 'Saving Private Ryan',
+          'cast': [
+            'Tom Hanks',
+            'Matt Damon'
+          ]
+        },
+        {
+          'id': 124,
+          'title': 'Forrest Gump',
+          'cast': 'Tom Hanks'
+        },
+      };
+
+      final values = items.pluck('cast');
+
+      expect(values, [
+        [
+          'Tom Hanks',
+          'Matt Damon'
+        ],
+        'Tom Hanks'
+      ]);
+    });
+  });
 }


### PR DESCRIPTION
I checked the [API docs](https://api.dart.dev/stable/2.17.3/dart-core/Set-class.html) for Dart Sets and  the available extensions here, it seems there is no extension for plucking values from set of maps using the key.  This might be a helpful capability for Sets so I added it.