### PR TITLE
Remove `DateTimeBasics.copyWith`, add `DateTimeBasics.addCalendarMonths`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.11.0]
+
+* Require Dart 2.19.
+
+* Removed `DateTimeBasics.copyWith` in favor of Dart 2.19's own `copyWith`
+  extension method on `DateTime`.
+
 ## [0.10.0]
 
 * Added `truncate` method to `String`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Removed `DateTimeBasics.copyWith` in favor of Dart 2.19's own `copyWith`
   extension method on `DateTime`.
 
+* Added `DateTimeBasics.addCalendarMonths`.
+
 ## [0.10.0]
 
 * Added `truncate` method to `String`.

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -83,7 +83,8 @@ extension DateTimeBasics on DateTime {
   /// the same contract.
   bool isAtOrAfter(DateTime other) => isAtSameMomentAs(other) || isAfter(other);
 
-  /// Adds a specified number of days to this [DateTime].
+  /// Returns a new [DateTime] computed from adding a specified number of days
+  /// to this one.
   ///
   /// Unlike `DateTime.add(Duration(days: numberOfDays))`, this adds calendar
   /// days and not 24-hour increments.  When possible, it therefore leaves the
@@ -98,7 +99,7 @@ extension DateTimeBasics on DateTime {
   /// Returns a negative value if the specified date is in the past.  Ignores
   /// the time of day.
   ///
-  /// Example:
+  /// Examples:
   /// ```
   /// DateTime(2020, 12, 31).calendarDaysTill(2021, 1, 1); // 1
   /// DateTime(2020, 12, 31, 23, 59).calendarDaysTill(2021, 1, 1); // 1
@@ -117,5 +118,24 @@ extension DateTimeBasics on DateTime {
     final startDay = DateTime.utc(this.year, this.month, this.day);
     final endDay = DateTime.utc(year, month, day);
     return (endDay - startDay).inDays;
+  }
+
+  /// Returns a new [DateTime] computed from adding a specified number of months
+  /// to this one.
+  ///
+  /// Attempts to preserve the day of the month and the time when possible.
+  /// If the current day of the month does not exist in the new month, the
+  /// last day of the new month will be returned.
+  ///
+  /// Examples:
+  /// ```
+  /// DateTime(2023, 1, 31, 2).addCalendarMonths(1); // 2023-02-28 02:00:00.000
+  /// DateTime(2023, 1, 31, 2).addCalendarMonths(-1) // 2022-12-31 02:00:00.000
+  /// ```
+  DateTime addCalendarMonths(int numberOfMonths) {
+    var newMonth = month + numberOfMonths;
+    var result = copyWith(month: newMonth);
+    var lastDayOfNewMonth = copyWith(month: newMonth + 1, day: 0);
+    return result.isAfter(lastDayOfNewMonth) ? lastDayOfNewMonth : result;
   }
 }

--- a/lib/date_time_basics.dart
+++ b/lib/date_time_basics.dart
@@ -83,31 +83,6 @@ extension DateTimeBasics on DateTime {
   /// the same contract.
   bool isAtOrAfter(DateTime other) => isAtSameMomentAs(other) || isAfter(other);
 
-  /// Copies a [DateTime], overriding specified values.
-  ///
-  /// A UTC [DateTime] will remain in UTC; a local [DateTime] will remain local.
-  DateTime copyWith({
-    int? year,
-    int? month,
-    int? day,
-    int? hour,
-    int? minute,
-    int? second,
-    int? millisecond,
-    int? microsecond,
-  }) {
-    return (isUtc ? DateTime.utc : DateTime.new)(
-      year ?? this.year,
-      month ?? this.month,
-      day ?? this.day,
-      hour ?? this.hour,
-      minute ?? this.minute,
-      second ?? this.second,
-      millisecond ?? this.millisecond,
-      microsecond ?? this.microsecond,
-    );
-  }
-
   /// Adds a specified number of days to this [DateTime].
   ///
   /// Unlike `DateTime.add(Duration(days: numberOfDays))`, this adds calendar

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,12 @@
 # license that can be found in the LICENSE file.
 
 name: basics
-version: 0.10.0
+version: 0.11.0
 description: A Dart library containing convenient extension methods on basic Dart objects.
 repository: https://github.com/google/dart-basics
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   characters: ^1.2.1

--- a/test/date_time_basics_test.dart
+++ b/test/date_time_basics_test.dart
@@ -86,7 +86,7 @@ void main() {
     });
   });
 
-  test('calendarDayTo works', () {
+  test('calendarDayTill works', () {
     expect(DateTime(2020, 12, 31).calendarDaysTill(2021, 1, 1), 1);
     expect(DateTime(2020, 12, 31, 23, 59).calendarDaysTill(2021, 1, 1), 1);
     expect(DateTime(2021, 1, 1).calendarDaysTill(2020, 12, 31), -1);
@@ -131,6 +131,47 @@ void main() {
       // This test is unfortunately dependent on the local timezone and is not
       // meaningful if the local timezone does not observe daylight saving time.
     }, skip: !_observesDaylightSaving());
+  });
+
+  group('addCalendarMonths:', () {
+    test('Works when adding 0 months', () {
+      var dt = DateTime(2020, 1, 1, 12, 34, 56);
+      expect(dt.addCalendarMonths(0), dt);
+    });
+
+    test('Preserves fields normally', () {
+      expect(
+        DateTime(2023, 1, 23, 12, 34, 56).addCalendarMonths(1),
+        DateTime(2023, 2, 23, 12, 34, 56),
+      );
+
+      expect(
+        DateTime(2023, 1, 31, 12, 34, 56).addCalendarMonths(2),
+        DateTime(2023, 3, 31, 12, 34, 56),
+      );
+
+      expect(
+        DateTime(2023, 1, 23, 12, 34, 56).addCalendarMonths(-1),
+        DateTime(2022, 12, 23, 12, 34, 56),
+      );
+
+      expect(
+        DateTime(2023, 1, 23, 12, 34, 56).addCalendarMonths(12),
+        DateTime(2024, 1, 23, 12, 34, 56),
+      );
+    });
+
+    test('Behaves when the day is invalid for the new month', () {
+      expect(
+        DateTime(2023, 1, 31, 12, 34, 56).addCalendarMonths(1),
+        DateTime(2023, 2, 28, 12, 34, 56),
+      );
+
+      expect(
+        DateTime(2023, 1, 31, 12, 34, 56).addCalendarMonths(-2),
+        DateTime(2022, 11, 30, 12, 34, 56),
+      );
+    });
   });
 }
 

--- a/test/date_time_basics_test.dart
+++ b/test/date_time_basics_test.dart
@@ -86,47 +86,6 @@ void main() {
     });
   });
 
-  group('copyWith:', () {
-    test('Copies existing values', () {
-      var copy = utcTime.copyWith();
-      expect(utcTime, isNot(same(copy)));
-      expect(utcTime, copy);
-
-      copy = localTime.copyWith();
-      expect(localTime, isNot(same(copy)));
-      expect(localTime, copy);
-    });
-
-    test('Overrides existing values', () {
-      final utcOverrides = DateTime.utc(2000, 1, 2, 3, 4, 5, 6, 7);
-      final localOverrides = utcOverrides.toLocal();
-
-      var copy = utcTime.copyWith(
-        year: utcOverrides.year,
-        month: utcOverrides.month,
-        day: utcOverrides.day,
-        hour: utcOverrides.hour,
-        minute: utcOverrides.minute,
-        second: utcOverrides.second,
-        millisecond: utcOverrides.millisecond,
-        microsecond: utcOverrides.microsecond,
-      );
-      expect(copy, utcOverrides);
-
-      copy = localTime.copyWith(
-        year: localOverrides.year,
-        month: localOverrides.month,
-        day: localOverrides.day,
-        hour: localOverrides.hour,
-        minute: localOverrides.minute,
-        second: localOverrides.second,
-        millisecond: localOverrides.millisecond,
-        microsecond: localOverrides.microsecond,
-      );
-      expect(copy, localOverrides);
-    });
-  });
-
   test('calendarDayTo works', () {
     expect(DateTime(2020, 12, 31).calendarDaysTill(2021, 1, 1), 1);
     expect(DateTime(2020, 12, 31, 23, 59).calendarDaysTill(2021, 1, 1), 1);


### PR DESCRIPTION
* Remove `DateTimeBasics.copyWith` in favor of Dart 2.19's own `copyWith`.
* Add an `addCalendarMonths` extension method for `DateTime`. (It probably could be named just `addMonths`, but I chose `addCalendarMonths` to match the `addCalendarDays` extension method.)

  Like `addCalendarDays`, `addCalendarMonths` will preserve more granular fields when possible.  We'll define the result of "adding N months" to mean the normalized `DateTime` with N added to the month value such that the day of the month either is preserved or is the last day of that month, whichever is earlier. (See the examples from the documentation.)
